### PR TITLE
Typo: change [si[ to [si]

### DIFF
--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -176,7 +176,7 @@ community channels see [Join our Community][cc].
 While technically possible, we haven't bundled it yet in a convenient package
 for anyone to run in the background. We are working hard to change that so we can
 help people operate Radicle nodes in many different ways. Should you be keen to
-have it as a daemon right now, check out how the [seed][si[ is implemented, and
+have it as a daemon right now, check out how the [seed][si] is implemented, and
 try to run your own.
  
 [ar]: using-radicle/tracking-and-viewing.md


### PR DESCRIPTION
In the FAQ, the link to seed info for the final question wasn't displayed on the website.

If you need to rebase, feel free to delete my PR and correct the typo yourself.