### PR TITLE
Add search config

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -101,6 +101,10 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   //   repoUrl: 'https://github.com/facebook/test-site',
+  algolia: {
+    apiKey: '8bd6e28f1096b67612c18dbc3ba55438',
+    indexName: 'radicle',
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Algolia finally got back to us. They configured an indexer for us on their free-tier, it runs every 24h. If we need changes to it we should open a PR at: https://github.com/algolia/docsearch-configs/blob/master/configs/radicle.json.

Closes: #46 

<img width="1385" alt="Screenshot 2021-01-04 at 10 28 13" src="https://user-images.githubusercontent.com/158411/103520550-9dc5e900-4e77-11eb-9c18-de9001b3fc14.png">