### PR TITLE
Link to radicle.xyz download page instead of deep-link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,12 +51,10 @@ follow along development in our [Matrix channel][mc] or on
 
 ### Supported Platforms
 
-Radicle Upstream is available for download on Linux and macOS (version 10.14 and
+Radicle Upstream is available for Linux and macOS (version 10.14 and
 newer).
 
-**→ [Download Radicle Upstream for Linux (AppImage)][d1]**
-
-**→ [Download Radicle Upstream for macOS (dmg)][d2]**
+**→ [You can download it here][do]**
 
 Once you've downloaded the binary for your respective platform, start it like
 this:
@@ -164,8 +162,7 @@ To start using Radicle, continue on to the [Using Radicle][ur] section.
 [as]: https://support.apple.com/en-us/HT211814
 [bs]: https://github.com/radicle-dev/radicle-upstream/blob/master/DEVELOPMENT.md
 [co]: https://radicle.community
-[d1]: https://releases.radicle.xyz/radicle-upstream-0.1.9.AppImage
-[d2]: https://releases.radicle.xyz/radicle-upstream-0.1.9.dmg
+[do]: https://radicle.xyz/downloads.html
 [gd]: https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup
 [sd]: https://github.com/radicle-dev/radicle-bins/tree/master/seed
 [te]: https://radicle.xyz/terms.html


### PR DESCRIPTION
This is to avoid having to make pull requests in two repositories when doing a release. We'll have to update the links
only in the radicle.xyz repository from now on.

<img width="794" alt="Screenshot 2021-02-01 at 12 57 42" src="https://user-images.githubusercontent.com/158411/106455913-217df000-648d-11eb-9952-7f9a1ccca7d1.png">
