### PR TITLE
Use a more obvious example URL

### DIFF
--- a/docs/using-radicle/running-a-seed-node.md
+++ b/docs/using-radicle/running-a-seed-node.md
@@ -53,7 +53,7 @@ TCP:80 to the machine where the seed node will be running.
 
 While not strictly necessary, it's nice to have a domain name set up for the
 public IP address as well. For this example, we'll use this record:
-`seed.my.org. A 1.2.3.4`.
+`seed.example.com. A 1.2.3.4`.
 
 Now you're ready to start the seed node. Let's configure it to listen on ports
 12345 and 80 on all interfaces, the private key is supplied via `STDIN`:
@@ -63,7 +63,7 @@ Now you're ready to start the seed node. Let's configure it to listen on ports
       --peer-listen 0.0.0.0:12345 \
       --http-listen 0.0.0.0:80 \
       --name "seedling" \
-      --public-addr "seed.my.org:12345" \
+      --public-addr "seed.example.com:12345" \
       --assets-path seed/ui/public \
       < ~/.radicle-seed/secret.key
 
@@ -82,18 +82,18 @@ in the seed address as `<SEED-ID>@<PUBLIC-ADDR>:<PORT>`.
       --peer-listen 0.0.0.0:12345 \
       --http-listen 0.0.0.0:80 \
       --name "seedling" \
-      --public-addr "seed.my.org:12345" \
+      --public-addr "seed.example.com:12345" \
       --assets-path seed/ui/public \
       < ~/.radicle-seed/secret.key
         Finished release [optimized] target(s) in 0.19s
-         Running `target/release/radicle-seed-node --root /Users/rudolfs/.radicle-seed --peer-listen '0.0.0.0:12345' --http-listen '0.0.0.0:80' --name seedling --public-addr 'seed.my.org:12345' --assets-path seed/ui/public`
+         Running `target/release/radicle-seed-node --root /Users/rudolfs/.radicle-seed --peer-listen '0.0.0.0:12345' --http-listen '0.0.0.0:80' --name seedling --public-addr 'seed.example.com:12345' --assets-path seed/ui/public`
     Nov 12 10:48:03.758  INFO radicle_seed: Initializing tracker to track everything..
     Nov 12 10:48:03.758  INFO Protocol::run{local.id=hyy5s7ysg96fqa91gbe7h38yddh4mkokft7y4htt8szt9e17sxoe3h local.addr=0.0.0.0:12345}: librad::net::protocol: Listening
     Nov 12 10:48:03.760  INFO Server::run{addr=0.0.0.0:80}: warp::server: listening on http://0.0.0.0:80
     Nov 12 10:48:03.760  INFO radicle_seed_node::frontend: Listening(0.0.0.0:12345)
 </details>
 
-Now point your browser http://seed.my.org. This is the seed node dashboard.
+Now point your browser to the address you set instead of http://seed.example.com. This is the seed node dashboard.
 
 ![Seed node UI][sn]
 
@@ -101,7 +101,7 @@ For Upstream clients to connect to your new seed, you'll need to share the seed
 address. This address can be found in the UI under the name of the seed. In our
 example the address is:
 
-    hyy5s7ysg96fqa91gbe7h38yddh4mkokft7y4htt8szt9e17sxoe3h@seed.my.org:12345
+    hyy5s7ysg96fqa91gbe7h38yddh4mkokft7y4htt8szt9e17sxoe3h@seed.example.com:12345
 
 Have a look at the [Adding a custom seed node][ad] section for more information
 on how to set up the new seed in Upstream.


### PR DESCRIPTION
Some people in chatroom didn't realise that seed.my.org is not an example domain. Use something more obvious - may as well follow RFC2606