### PR TITLE
Add a section in the FAQ about deep linking

### DIFF
--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -217,6 +217,10 @@ EOF
 update-desktop-database ~/.local/share/applications
 ```
 
+**Note**: It's advisable to move the Upstream binary to a stable location,
+before registering the custom protocol, otherwise the custom protocol
+handling will break if the binary is moved.
+
 To verify whether the custom protocol was registered by launching Upstream via
 a custom URI from your terminal:
 ```sh

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -186,7 +186,7 @@ help people operate Radicle nodes in many different ways. Should you be keen to
 have it as a daemon right now, check out how the [seed][si] is implemented, and
 try to run your own.
 
-## Is it possible to open radicle URIs directly in Upstream?
+## Is it possible to launch Upstream via links on the web?
 Yes, as of Upstream v0.1.13 we support opening links to Radicle projects in
 Upstream. Clicking the following link will launch Upstream and navigate to the
 specified project:

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -187,11 +187,11 @@ have it as a daemon right now, check out how the [seed][si] is implemented, and
 try to run your own.
 
 ## Is it possible to launch Upstream via links on the web?
-Yes, as of Upstream v0.1.13 we support opening links to Radicle projects in
+Yes, as of Upstream v0.2.1 we support opening links to Radicle projects in
 Upstream. Clicking the following link will launch Upstream and navigate to the
 specified project:
 
-  radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo
+  radicle://link/v0/rad:git:hnrkmzko1nps1pjogxadcmqipfxpeqn6xbeto
 
 The custom protocol is registered automatically when installing Upstream on
 macOS.
@@ -201,15 +201,15 @@ integrate Upstream into your system with `AppImageLauncher` or `appimaged` as
 described [here][ai].
 
 Assuming you have downloaded the latest Upstream in
-`$HOME/Downloads/radicle-upstream-0.1.13.AppImage`, you can register the
+`$HOME/Downloads/radicle-upstream-0.2.1.AppImage`, you can register the
 protocol by running the following commands:
 
 ```sh
-chmod +x $HOME/Downloads/radicle-upstream-0.1.13.AppImage
+chmod +x $HOME/Downloads/radicle-upstream-0.2.1.AppImage
 
 cat > $HOME/.local/share/applications/radicle-upstream.desktop <<EOF
 [Desktop Entry]
-Exec=$HOME/Downloads/radicle-upstream-0.1.13.AppImage %U
+Exec=$HOME/Downloads/radicle-upstream-0.2.1.AppImage %U
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/radicle;
@@ -224,7 +224,7 @@ handling will break if the binary is renamed or moved to another location.
 
 On Linux you can verify whether the custom protocol is working like this:
 ```sh
-xdg-open "radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo"
+xdg-open "radicle://link/v0/rad:git:hnrkmzko1nps1pjogxadcmqipfxpeqn6xbeto"
 ```
 
 Read more about the custom Radicle client URI scheme [here][cu].

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -185,9 +185,51 @@ for anyone to run in the background. We are working hard to change that so we ca
 help people operate Radicle nodes in many different ways. Should you be keen to
 have it as a daemon right now, check out how the [seed][si] is implemented, and
 try to run your own.
- 
+
+## Is it possible to open radicle URIs directly in Upstream?
+Yes, as of Upstream v0.1.13 we support opening links to Radicle projects in
+Upstream. Clicking the following link will launch Upstream and navigate to the
+specified project:
+
+  radicle://v0/link/rad:git:hwd1yredna5k7undw9xurpm6mtfyczodz4fkute7bcpii3jb9uoj7tf1sho?action=show
+
+The custom protocol is registered automatically when installing Upstream on
+macOS.
+
+On Linux you'll have to either manually register the custom protocol or
+[integrate Upstream into your system][ai] with AppImageLauncher or appimaged.
+
+Assuming you have downloaded the latest upstream in
+`$HOME/Downloads/radicle-upstream-0.1.13.AppImage`, you can register the
+protocol by running the following commands:
+
+```
+chmod +x $HOME/Downloads/radicle-upstream-0.1.13.AppImage
+
+cat > $HOME/.local/share/applications/radicle-upstream.desktop <<EOF
+[Desktop Entry]
+Exec=$HOME/Downloads/radicle-upstream-0.1.13.AppImage %U
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/radicle;
+EOF
+
+update-desktop-database ~/.local/share/applications
+```
+
+To verify whether the custom protocol was registered by launching Upstream via
+a custom URI from your terminal:
+```
+xdg-open "radicle://v0/link/rad:git:hwd1yredna5k7undw9xurpm6mtfyczodz4fkute7bcpii3jb9uoj7tf1sho?action=show"
+```
+
+Read more about the custom Radicle client URI scheme [here][cu].
+
+
+[ai]: https://docs.appimage.org/user-guide/run-appimages.html#integrating-appimages-into-the-desktop
 [ar]: using-radicle/tracking-and-viewing.md
 [cp]: using-radicle/creating-projects.md
+[cu]: https://github.com/radicle-dev/radicle-decisions/blob/63ed45c2dc3e2c4b8e1a02619dcf26f957e5fdfe/proposals/0004.md
 [ov]: using-radicle/overview.md
 [gs]: getting-started.md
 [hw]: how-it-works.md/#git-implementation

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -197,9 +197,10 @@ The custom protocol is registered automatically when installing Upstream on
 macOS.
 
 On Linux you'll have to either manually register the custom protocol or
-[integrate Upstream into your system][ai] with AppImageLauncher or appimaged.
+integrate Upstream into your system with `AppImageLauncher` or `appimaged` as
+described [here][ai].
 
-Assuming you have downloaded the latest upstream in
+Assuming you have downloaded the latest Upstream in
 `$HOME/Downloads/radicle-upstream-0.1.13.AppImage`, you can register the
 protocol by running the following commands:
 
@@ -217,12 +218,11 @@ EOF
 update-desktop-database ~/.local/share/applications
 ```
 
-**Note**: It's advisable to move the Upstream binary to a stable location,
+**Note**: It's advisable to move the Upstream binary to a stable location
 before registering the custom protocol, otherwise the custom protocol
-handling will break if the binary is moved.
+handling will break if the binary is renamed or moved to another location.
 
-To verify whether the custom protocol was registered by launching Upstream via
-a custom URI from your terminal:
+On Linux you can verify whether the custom protocol is working like this:
 ```sh
 xdg-open "radicle://v0/link/rad:git:hwd1yredna5k7undw9xurpm6mtfyczodz4fkute7bcpii3jb9uoj7tf1sho?action=show"
 ```

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -191,7 +191,7 @@ Yes, as of Upstream v0.1.13 we support opening links to Radicle projects in
 Upstream. Clicking the following link will launch Upstream and navigate to the
 specified project:
 
-  radicle://v0/link/rad:git:hwd1yredna5k7undw9xurpm6mtfyczodz4fkute7bcpii3jb9uoj7tf1sho?action=show
+  radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo
 
 The custom protocol is registered automatically when installing Upstream on
 macOS.
@@ -224,7 +224,7 @@ handling will break if the binary is renamed or moved to another location.
 
 On Linux you can verify whether the custom protocol is working like this:
 ```sh
-xdg-open "radicle://v0/link/rad:git:hwd1yredna5k7undw9xurpm6mtfyczodz4fkute7bcpii3jb9uoj7tf1sho?action=show"
+xdg-open "radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo"
 ```
 
 Read more about the custom Radicle client URI scheme [here][cu].
@@ -233,7 +233,7 @@ Read more about the custom Radicle client URI scheme [here][cu].
 [ai]: https://docs.appimage.org/user-guide/run-appimages.html#integrating-appimages-into-the-desktop
 [ar]: using-radicle/tracking-and-viewing.md
 [cp]: using-radicle/creating-projects.md
-[cu]: https://github.com/radicle-dev/radicle-decisions/blob/63ed45c2dc3e2c4b8e1a02619dcf26f957e5fdfe/proposals/0004.md
+[cu]: https://github.com/radicle-dev/radicle-decisions/blob/master/proposals/0004.md
 [ov]: using-radicle/overview.md
 [gs]: getting-started.md
 [hw]: how-it-works.md/#git-implementation

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -203,7 +203,7 @@ Assuming you have downloaded the latest upstream in
 `$HOME/Downloads/radicle-upstream-0.1.13.AppImage`, you can register the
 protocol by running the following commands:
 
-```
+```sh
 chmod +x $HOME/Downloads/radicle-upstream-0.1.13.AppImage
 
 cat > $HOME/.local/share/applications/radicle-upstream.desktop <<EOF
@@ -219,7 +219,7 @@ update-desktop-database ~/.local/share/applications
 
 To verify whether the custom protocol was registered by launching Upstream via
 a custom URI from your terminal:
-```
+```sh
 xdg-open "radicle://v0/link/rad:git:hwd1yredna5k7undw9xurpm6mtfyczodz4fkute7bcpii3jb9uoj7tf1sho?action=show"
 ```
 


### PR DESCRIPTION
Add instructions on how to register the `radicle://` custom protocol on Linux.

  - [x] update minimum supported Upstream version number once it's known
  - [x] adjust link scheme if there are changes to https://github.com/radicle-dev/radicle-decisions/pull/10

⚠️ We should merge this only after https://github.com/radicle-dev/radicle-upstream/pull/1652 is publicly released.
