### PR TITLE
remove obsolete license headers

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 const React = require('react');
 
 class Footer extends React.Component {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 // See https://docusaurus.io/docs/site-config for all the possible
 // site configuration options.
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 @import url("https://rsms.me/inter/inter.css");
 
 @font-face {


### PR DESCRIPTION
Remove obsolete license headers and copyright information. The license headers in these files were left overs from the original code. This code has been removed so the license does not apply anymore.

Fixes #162