### PR TITLE
Remove additional Upstream references

### DIFF
--- a/docs/get-involved/community.md
+++ b/docs/get-involved/community.md
@@ -5,42 +5,53 @@ title: Join the Community
 
 To get involved with the Radicle project, start by joining our community channels:
 
-### Join our [Matrix chat][mc]
-_For real-time discussion on everything related to Radicle_
+### [Discord](https://discord.gg/j2HZCBDUvF)
 
-The best way to join our chat is by making an account on
-[matrix.radicle.community][mc] and joining our [community homepage][ch]. This is where you
-can find a list of our available rooms. The address for our homeserver is **matrix.radicle.xyz**.
+Most conversations in the community are happening here. The core team is very active and typically responds to questions
+in real time.
 
-→ [**#general**][gn] for introductions and general discussions about Radicle development
+[discord.com](https://discord.gg/dZK4TxaU2v)
 
-→ [**#support**][sp] for answering questions and other support-related discussions
+## [Discourse](https://radicle.community/)
 
-→ [**#gov**][gv] for discussing Radicle governance proposals and process
+The hub for all longer-form discussions about the project. The team uses it regularly to share project-wide
+announcements, releases, feature updates, and more.
 
-→ [**#token**][tn] for all conversation regarding the Radicle token
+[radicle.community](https://radicle.community/)
 
+## [Twitter](https://twitter.com/radicle)
 
-### Join our [community forum][cf]
-_For longer-form discussions on feature requests, development
-decisions, and other general topics_
+We use our Twitter to share announcements & project-wide updates, as well as amplify Radicle-aligned messaging from
+partnerships and the greater ecosystem. We don't offer support here.
 
-### Subscribe to our [telegram channel][tc]
-_For announcements from the Radicle project_
+[@radicle](https://twitter.com/radicle)
 
-### Follow us on twitter - [@radicle][tl]
-_For announcements and release updates_
+## [GitHub](https://github.com/radicle-dev)
 
-### Subscribe to our [email list][el] 
-_For announcements and release updates_
+GitHub
 
-[mc]: https://matrix.radicle.community/
-[sp]: https://matrix.to/#/#support:radicle.community
-[gn]: https://matrix.to/#/#general:radicle.community
-[gv]: https://matrix.to/#/#gov:radicle.community
-[tn]: https://matrix.to/#/#token:radicle.community
-[ch]: https://matrix.to/#/+home:radicle.community
-[cf]: https://radicle.community/
-[tl]: https://twitter.com/radicle
-[el]: http://eepurl.com/hhHxMX
-[tc]: https://t.me/radicleworld
+All Radicle development is open-source and public by default. The radicle-dev GitHub is consistently active and is the
+best place to see what the team is working on.
+
+[github.com/radicle-dev](https://github.com/radicle-dev)
+
+## [Matrix](https://matrix.radicle.community/)
+
+Some of the core team uses Matrix, and the Discord channels are mirrored here. Information on Matrix is almost the same
+as Discord.
+
+[matrix.radicle.community](https://matrix.radicle.community/)
+
+## [Telegram](https://t.me/radicleworld)
+
+Larger announcements are posted in our official Telegram channel. There are also other channels sprouting up which are
+quite active.
+
+[t.me/radicleworld](https://t.me/radicleworld)
+
+## [Newsletter](http://eepurl.com/hhHxMX)
+
+If you'd like to stay updated about product releases, project updates, and other announcements, hand us your e-mail and
+we'll keep you in the loop.
+
+[Stay up to date](http://eepurl.com/hhHxMX)

--- a/docs/get-involved/community.md
+++ b/docs/get-involved/community.md
@@ -21,7 +21,7 @@ announcements, releases, feature updates, and more.
 
 ## [Twitter](https://twitter.com/radicle)
 
-We use our Twitter to share announcements & project-wide updates, as well as amplify Radicle-aligned messaging from
+We use Twitter to share announcements & project-wide updates, as well as amplify Radicle-aligned messaging from
 partnerships and the greater ecosystem. We don't offer support here.
 
 [@radicle](https://twitter.com/radicle)
@@ -30,8 +30,8 @@ partnerships and the greater ecosystem. We don't offer support here.
 
 GitHub
 
-All Radicle development is open-source and public by default. The radicle-dev GitHub is consistently active and is the
-best place to see what the team is working on.
+All Radicle development is open-source and public by default. The radicle-dev GitHub account is consistently active and
+is the best place to see what the team is working on.
 
 [github.com/radicle-dev](https://github.com/radicle-dev)
 
@@ -55,3 +55,6 @@ If you'd like to stay updated about product releases, project updates, and other
 we'll keep you in the loop.
 
 [Stay up to date](http://eepurl.com/hhHxMX)
+
+Most disucssions related to development of the [Radicle Link](https://github.com/radicle-dev/radicle-link) protocol
+happen on their [mailing list](https://lists.sr.ht/~radicle-link/dev).

--- a/docs/get-involved/community.md
+++ b/docs/get-involved/community.md
@@ -5,7 +5,7 @@ title: Join the Community
 
 To get involved with the Radicle project, start by joining our community channels:
 
-### [Discord](https://discord.gg/j2HZCBDUvF)
+## [Discord](https://discord.gg/j2HZCBDUvF)
 
 Most conversations in the community are happening here. The core team is very active and typically responds to questions
 in real time.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ To interact with the Radicle network, you need an **identity**, which you genera
 After choosing a display name and setting a passphrase, the Radicle CLI generates two unique identifiers.
 
 First is your **Peer ID**, which identifies your device and the code you publish on the Radicle network, and is secured
-with an Ed25519 keypair. Second is your **personal 🌱 URN**, which identifies your project on the Radicle network.
+with an Ed25519 keypair. Second is your **personal 🌱 URN**, which identifies you across devices.
 
 ```
 $ rad auth
@@ -118,22 +118,27 @@ You can use `rad auth` to create and manage multiple Radicle identities, but we'
 
 ## Create your Radicle project from a Git repository
 
-`rad init` creates a unique identity for your repository and associates your Peer ID with it for sharing on the Radicle
+`rad init` creates a **project URN** for your repository and associates your Peer ID with it for sharing on the Radicle
 network.
 
 Navigate to an existing Git repository, run `rad init`, enter a description, and specify the name of your default branch
 (typically `master` or `main`).
 
 ```
-$ rad init
-Initializing local 🌱 project acme
+Initializing local 🌱 project in .
 
+ok Name · acme
 ok Description · The Acme Corporation is an ironic name for the fictional corporation
 ok Default branch · main
-ok Initializing new project...
-ok Project initialized: rad:git:hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo
+ok Initializing...
+ok Created .gitsigners file
+ok Signing key configured
 
-=> To publish, run `rad push`.
+Your project id is rad:git:hnrknpgjwt6uiyx13as9hfrx994nxc6zdei1y. You can show it any time by running:
+   rad .
+
+To publish your project to the network, run:
+   rad push
 ```
 
 ## Publish your code on the Radicle network
@@ -151,33 +156,36 @@ public internet. Radicle offers three default seed nodes: [pine.radicle.garden](
 ```
 $ rad push
 Pushing 🌱 to remote `rad`
+$ git push rad
 Everything up-to-date
 
 Git version 2.35.1
 Select a seed node to sync with...
+
 * pine.radicle.garden
 * willow.radicle.garden
 * maple.radicle.garden
 ```
 
 Once your project finishes syncing for the first time, you'll find important information about where your project lives
-on the Radicle Network.
+on the Radicle network.
 
 ```
-Git signing key ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL460KIEccS4881p7PPpiiQBsxF+H5tgC6De6crw9rbU
+Radicle signing key ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBndIloOmjGvHkqgfJ9sEkaZb1iBG9lrfjODqG5uoqjV
 
-Syncing 🌱 project rad:git:hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo to https://willow.radicle.garden
+Syncing 🌱 project rad:git:hnrknpgjwt6uiyx13as9hfrx994nxc6zdei1y to https://willow.radicle.garden/
 
-ok Syncing delegate identity hnrkqdpm9ub19oc8dccx44echy76hzfsezyio...
-ok Syncing project identity...
-ok Syncing project refs...
-ok Fetching remotes (*)...
 ok Project synced.
 
-🌱 Your project is synced and available at:
+🍃 Your project is available at:
 
-    (web) https://app.radicle.network/seeds/willow.radicle.garden/rad:git:hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo/
-    (git) https://willow.radicle.garden/hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo.git
+   (web) https://app.radicle.network/seeds/willow.radicle.garden/rad:git:hnrknpgjwt6uiyx13as9hfrx994nxc6zdei1y
+   (web) https://app.radicle.network/seeds/willow.radicle.garden/rad:git:hnrknpgjwt6uiyx13as9hfrx994nxc6zdei1y/remotes/hyyc74e14b4pddma6jko8385cnjdj154aorp71456gqb4o5uqwkwpk
+   (git) https://willow.radicle.garden/hnrknpgjwt6uiyx13as9hfrx994nxc6zdei1y.git
+
+ok Saving seed configuration to local git config...
+=> To override the seed, pass the '--seed' flag to `rad sync` or `rad push`.
+=> To change the configured seed, run `git config rad.seed <url>` with a seed URL.
 ```
 
 Note the `(web)` and `(git)` URLs, which you'll use in the next step.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,7 @@ or design.
       of Content.
     </p>
     <p>
-      Read the rest of our Terms of Use [here][te].
+      Read the rest of our Terms of Use [here](https://radicle.xyz/terms.html).
     </p>
   </em>
 </details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,9 +83,10 @@ brew tap radicle/cli https://seed.alt-clients.radicle.xyz/radicle-cli-homebrew.g
 brew install radicle/cli/core
 ```
 
-> **M1/arm64 users**: We're still working on an ideal installation method for running Radicle CLI on your
-> machine&mdash;see this [GitHub Gist](https://gist.github.com/sebastinez/d8f2d4979cad0d9f23c162702cdd4735) for our
-> latest progress until we're ready to publish an official method.
+> **M1/Apple Silicon users**: We're still working on an ideal installation method for running Radicle CLI on your
+> machine&mdash;see [our M1 troubleshooting
+> section](understanding-radicle/troubleshooting.md##install-radicle-cli-on-apple-silicon) for our latest progress
+> until we're ready to publish an official method.
 
 ## Create your Radicle identity
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,9 +91,10 @@ brew install radicle/cli/core
 
 To interact with the Radicle network, you need an **identity**, which you generate with `rad auth`.
 
-After choosing a display name and setting a passphrase, the Radicle CLI generates two unique identifiers, your **Peer
-ID** and **personal 🌱 URN**, which identify your device and identify you across devices, respectively, along with an
-Ed25519 keypair for securing your identity.
+After choosing a display name and setting a passphrase, the Radicle CLI generates two unique identifiers.
+
+First is your **Peer ID**, which identifies your device and the code you publish on the Radicle network, and is secured
+with an Ed25519 keypair. Second is your **personal 🌱 URN**, which identifies your project on the Radicle network.
 
 ```
 $ rad auth

--- a/docs/radicle.md
+++ b/docs/radicle.md
@@ -4,8 +4,6 @@ title: What is Radicle?
 sidebar_label: What is Radicle?
 ---
 
-> **To start hosting code the Radicle network, see our [getting started guide](getting-started.md).**
-
 Radicle is a decentralized code collaboration network built on open protocols 🌱. It enables developers
 to collaborate on code without relying on trusted intermediaries. Radicle was designed
 to provide similar functionality to centralized code collaboration platforms — or "forges" —
@@ -15,8 +13,18 @@ version control so powerful in the first place.
 Read more about our [vision for decentralized code
 collaboration](https://radicle.xyz/blog/towards-decentralized-code-collaboration.html).
 
-Radicle also features an [*opt-in* Ethereum integration][https://radicle.xyz/blog/integrating-with-ethereum.html] for
+Radicle also features an [*opt-in* Ethereum integration](https://radicle.xyz/blog/integrating-with-ethereum.html) for
 unique global names, decentralized organizations, and protocols that help maintainers sustain their open-source work.
+
+## How do I use Radicle?
+
+The best way to start hosting code on the Radicle network is to use the [Radicle CLI](https://radicle.network/), which
+helps you create a identity, initialize a repository, host your code on a [seed
+node](understanding-radicle/glossary/#seed), and share your project with others.
+
+> **To start hosting code the Radicle network, see our [getting started guide](getting-started.md).**
+
+Additional discovery and collaboration features are planned and under active development.
 
 ## How Radicle works
 
@@ -59,14 +67,3 @@ projects that can be fetched and merged by other peers via patches.
 
 > Read more about [collaborating on Radicle](https://radicle.xyz/blog/collaborating-on-radicle.html) and our social
 > model.
-
-## How do I use Radicle?
-
-The best way to start hosting code on the Radicle network is to use the [Radicle CLI](https://radicle.network/), which
-helps you create a identity, initialize a repository, host your code on a [seed
-node](understanding-radicle/glossary/#seed), and share your project with others.
-
-[Get started](getting-started.md) in just a few steps.
-
-> Additional discovery and collaboration features, like pulling patches for review, are planned and under active
-> development.

--- a/docs/radicle.md
+++ b/docs/radicle.md
@@ -8,13 +8,14 @@ Radicle is a decentralized code collaboration network built on open protocols �
 to collaborate on code without relying on trusted intermediaries. Radicle was designed
 to provide similar functionality to centralized code collaboration platforms — or "forges" —
 while retaining Git’s peer-to-peer nature, building on what made distributed
-version control so powerful in the first place.
+version control so powerful in the first place. 
 
 Read more about our [vision for decentralized code
 collaboration](https://radicle.xyz/blog/towards-decentralized-code-collaboration.html).
 
-Radicle also features an [*opt-in* Ethereum integration](https://radicle.xyz/blog/integrating-with-ethereum.html) for
-unique global names, decentralized organizations, and protocols that help maintainers sustain their open-source work.
+Radicle is also [Drips](https://www.drips.network/), an Ethereum protocol for generating recurring income with
+subscriptions and NFT memberships. Drips helps you create a circular funding network by dripping funds to your favorite
+creators and dedicating a percentage of your incoming drips to others.
 
 ## How do I use Radicle?
 

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -3,8 +3,9 @@ id: faq
 title: FAQ
 ---
 ## How do I get started?
-Head over to the [Getting Started][gs] section for instructions on how to
-download and install the Radicle Upstream client.
+Head over to [getting started](getting-started.md) section for instructions on how to download and 
+install the Radicle CLI, which helps you host code on the Radicle network and
+collaborate on projects.
 
 ## How is collaborating on Radicle different than GitHub?
 In contrast to centralized code collaboration platforms, Radicle is designed for
@@ -14,8 +15,7 @@ of their social interactions as they self-host their own content and the content
 of any peers they are interested in. This also means that within projects, there
 isn't a single `master` branch that contributors merge into. Each peer maintains
 a view of a project with their changesets and branches. These views are gossiped
-around to other peers that are interested in those changes. Read more about the
-implications and approach to this design [here][ov].
+around to other peers that are interested in those changes.
 
 ## How is Radicle more secure than centralized platforms?
 The Radicle network is peer-to-peer and built on public key cryptography. To
@@ -28,10 +28,13 @@ interface components and key oracles to signal trust from user to user, Radicle
 has designed trust into the core of the protocol.
 
 ## How does Radicle interact with Git?
-Radicle Link — the protocol that powers the Radicle network is built on Git. All
-Radicle data is stored in a single Git monorepo on your machine that is read
-from and written to via the Upstream client. To read more
-about Radicle's Git Implementation, see [How it Works][hw].
+
+The Radicle CLI uses a push-pull transport mechanism that's built on top of Git. When you run `rad init` in a Git
+repository for the first time, it adds a `rad` remote that points to the project's local state, which you then push to a
+seed node when you run `rad push`.
+
+The Radicle CLI also uses the identity portion of [Radicle Link](https://github.com/radicle-dev/radicle-link)) to create
+unique Peer IDs and personal URNs, which identify your devices and your identity across devices, respectively.
 
 ## How is Radicle licensed?
 Radicle is completely free and open-source. It's licensed under version 3 of the
@@ -46,14 +49,17 @@ issues, PRs, and discussions will be more secure, available offline, and stored
 on your machine as git objects — not on a central server!
 
 ## When will CLI tooling be available?
-We're working on it! 🤞 We will introduce CLI tooling alongside of Upstream
-development.
+
+The [Radicle CLI](https://github.com/radicle-dev/radicle-cli/) is available now, and is currently the best way to [get
+started](getting-started.md) with hosting code on the Radicle network.
 
 ## Can I backup a GitHub project on Radicle?
+
 Yes! Publishing a codebase to Radicle is a great way to create a peer-to-peer
 backup of your repositories. Maintaining a mirror of a project on Radicle is as
-simple as pushing to another remote. Read more about [creating
-projects][cp].
+simple as pushing to another remote. 
+
+To create a mirror, follow the [getting started](getting-started.md) guide using your existing repository, which will initiatize your project and push the code to the Radicle network. To synchronize state between your GitHub and Radicle versions, run `rad push` on the `main`/`master` branch after every change.
 
 ## Can I replace GitHub with Radicle?
 If you want! While our Beta release will have only the basic collaboration features
@@ -64,17 +70,27 @@ discussions.
 
 That being said, while we believe that reducing one's reliance on
 centrally-hosted platforms is generally a good idea, we also believe that code
-collaboration solutions serve different purposes for different people. Radicle
-Upstream *will* support social collaboration, but it's priority will be
+collaboration solutions serve different purposes for different people. Radicle *will* support social collaboration through one or more projects, but our priority will be
 delivering secure, local-first, peer-to-peer code collaboration — not an exact
 GitHub replica.
 
 ## Where is my data stored?
-On the Radicle network, content is distributed peer-to-peer via a process called
-gossip. This means that peers self-host their own content — and the content of
+
+There are currently two methods of transporting data on the Radicle network.
+
+The original method is through a distributed peer-to-peer via a process called
+**gossip**. This means that peers self-host their own content — and the content of
 any peers they are interested in — locally on their machine in a [Git monorepo][hw].
 It also means that whenever your data is published to the network, it can be
 replicated and stored on another peer's machine.
+
+The newer method is a **push-pull** method that uses `git push` to send changes to seed nodes and `git pull` to fetch
+updates. With this method, your data is only stored on the seed node you chose to sync your project with when you [ran
+`rad init`](getting-started.md#create-your-radicle-project-from-a-git-directory), and with anyone who uses `rad clone`
+to create a copy of the project.
+
+Currently, only the push-pull method is utilized by the [CLI tooling](https://github.com/radicle-dev/radicle-cli/), but
+there are plans to re-introduce the P2P gossip method, and potentially allow users to choose which method they prefer.
 
 ## Can I create private repositories on Radicle?
 No, not yet - but in the future! Private projects with end-to-end encryption are
@@ -88,63 +104,42 @@ their remotes to be able to fetch changes from them. You can manage remotes
 on your project page (See [Adding Remotes][ar]). For more on how remote
 repositories work, see the [Git documentation][mr].
 
-## What's a Radicle ID?
-A Radicle ID is a unique way of identifying projects in the Radicle Network.
-You can find it on a project's page or on the [seed node dashboard][sn]. You
-use a project's Radicle ID to find it via Radicle Upstream.
+## What's a Peer ID?
 
-## What's a Device ID?
-A Device ID is the encoding of a peer's public key that is tied to a specific device.
-People will be able to manage multiple Device IDs in the future, but for now you can
-only have one Device ID per identity.
+A Peer ID identifies your device and the code you publish on the Radicle network, and is secured with an
+Ed25519 keypair.
 
-To be [added as a remote][ar] to a project, you need to share your Device ID.
+You can create multiple identities using `rad auth`.
 
-## What does following mean in Radicle?
-Following a project replicates its data to your machine by tracking it. This
-allows the follower to subscribe to updates from the project's maintainer(s) or
-other remotes. It is also a way to signal interest in the project or peer by
-further replicating the data across their network, making it available to other
-people on the network. See [Tracking][tr].
+## What's a personal URN?
+
+A **personal URN** which identifies your project on the Radicle network. You can use these URNs to find a project on the
+Radicle [web client](https://app.radicle.network/) or clone a project with `rad clone`.
+
+If you want to share your project with a collaborator, make sure you share its URN.
 
 ## Can I use Radicle with multiple devices?
-Yes and no. While there isn't multi-device support yet, you can still create
-accounts on different devices, they just won't be linked under one Upstream user
-account.
+
+Yes and no. 
+
+There is no explicit support, but if you got started with the Radicle network using the CLI tooling, you can, in theory,
+use the same keyfile (`librad.key`) to authenticate the same Peer ID on multiple devices, which would allow you to
+push/pull code to the same project without having to manage multiple identities.
 
 ## How do I make sure nobody else has my display name?
 You can't.... yet. We will be introducing unique names soon 👍
 
-(P.S. While your display name isn't unique, your emoji avatar is!)
-
 ## What happens if I forget my passphrase?
-Without your passphrase, there is no way to grant the Upstream client access to
-your secret key. This means that without your passphrase, there is no way to
-access or publish data to the Radicle network - so make sure you keep it safe!
+
+Without your passphrase, Radicle tools can't use the secret keypair that validates your Peer ID on the network, which means you've lost access to push to existing projects on the Radicle network. Make sure you keep it safe!
 
 ## Can I change my passphrase?
 Not yet — so make sure to keep it in a safe place!
 
-## Why do I have to enter my passphrase everytime?
-Interactions through Git and the remote helper are ad-hoc and don't have the
-benefit of a long-running daemon - i.e. Upstream client. That means for now the
-passphrase has to be provided every time you interact with Radicle outside of
-a client.
+## Why do I have to enter my passphrase every time ?
 
-## I can't find a project on the network or see a peer's changes. What should I do?
-First, check to see if you are connected to the seed node by hovering over the
-Connection Status icon in your toolbar. If you are connected to one or more
-peer, navigate to the seed node dashboard (e.g. sprout.radicle.xyz) to see if
-you can find your Device ID.
-
-![Seed Dashboard Search][sd]
-
-If you are connected to the seed node and can find yourself on the dashboard,
-try restarting the app. On restart, if there is still outstanding data to be
-found, try refreshing the app. Wait one minute before restarting the app again.
-
-If you are still running into problems, please submit a request in our [#support
-channel][sc].
+You shouldn't need to enter your passphrase every time you interact with the Radicle network. Depending on your setup,
+you may need to enter it once after login using `rad auth`.
 
 ## Can I delete a project?
 Currently, this feature is not supported but it is on the roadmap and will be
@@ -152,12 +147,6 @@ included in an upcoming release. Until then, you can only remove your
 project from your local machine, thus limiting the number of peers who can find
 and replicate your project. You can not delete a project from another peer's
 local machine, as they retain control over their local data.
-
-## Why am I only connected to one peer?
-By default, the Upstream client is conecting to a seed node operated by Radicle.
-While we support [epidemic broadcast][eb] to find and connect to other peers, we
-don't have support for [hole punching][hp] just yet, which will prevent a stable conenction
-between two computers.
 
 ## I ran into a issue, where can I report it?
 Please reach out to us in our [#support channel][sc], or submit an issue on our
@@ -178,56 +167,6 @@ To join our Matrix chat, follow these steps:
 To join our Matrix chat with an account from another Matrix server, you can use
 this [direct invite link][mc] to join #general. For more information on our
 community channels see [Join our Community][cc].
-
-## Can I run Radicle as a daemon?
-While technically possible, we haven't bundled it yet in a convenient package
-for anyone to run in the background. We are working hard to change that so we can
-help people operate Radicle nodes in many different ways. Should you be keen to
-have it as a daemon right now, check out how the [seed][si] is implemented, and
-try to run your own.
-
-## Is it possible to launch Upstream via links on the web?
-Yes, as of Upstream v0.2.1 we support opening links to Radicle projects in
-Upstream. Clicking the following link will launch Upstream and navigate to the
-specified project:
-
-  radicle://link/v0/rad:git:hnrkmzko1nps1pjogxadcmqipfxpeqn6xbeto
-
-The custom protocol is registered automatically when installing Upstream on
-macOS.
-
-On Linux you'll have to either manually register the custom protocol or
-integrate Upstream into your system with `AppImageLauncher` or `appimaged` as
-described [here][ai].
-
-Assuming you have downloaded the latest Upstream in
-`$HOME/Downloads/radicle-upstream-0.2.1.AppImage`, you can register the
-protocol by running the following commands:
-
-```sh
-chmod +x $HOME/Downloads/radicle-upstream-0.2.1.AppImage
-
-cat > $HOME/.local/share/applications/radicle-upstream.desktop <<EOF
-[Desktop Entry]
-Exec=$HOME/Downloads/radicle-upstream-0.2.1.AppImage %U
-Terminal=false
-Type=Application
-MimeType=x-scheme-handler/radicle;
-EOF
-
-update-desktop-database ~/.local/share/applications
-```
-
-**Note**: It's advisable to move the Upstream binary to a stable location
-before registering the custom protocol, otherwise the custom protocol
-handling will break if the binary is renamed or moved to another location.
-
-On Linux you can verify whether the custom protocol is working like this:
-```sh
-xdg-open "radicle://link/v0/rad:git:hnrkmzko1nps1pjogxadcmqipfxpeqn6xbeto"
-```
-
-Read more about the custom Radicle client URI scheme [here][cu].
 
 
 [ai]: https://docs.appimage.org/user-guide/run-appimages.html#integrating-appimages-into-the-desktop

--- a/docs/understanding-radicle/faq.md
+++ b/docs/understanding-radicle/faq.md
@@ -97,26 +97,24 @@ No, not yet - but in the future! Private projects with end-to-end encryption are
 on our roadmap. In the meantime, be sure to note that everything you put on
 Radicle will be publicly available.
 
-## What is a remote?
+## What's a remote?
 A remote refers to a version of your project that is maintained by another
 person. To collaborate with others on Radicle, you have to add and follow other
 their remotes to be able to fetch changes from them. You can manage remotes
 on your project page (See [Adding Remotes][ar]). For more on how remote
 repositories work, see the [Git documentation][mr].
 
-## What's a Peer ID?
+## What's the difference between a Peer ID, a personal URN, and a project URN?
 
-A Peer ID identifies your device and the code you publish on the Radicle network, and is secured with an
-Ed25519 keypair.
+In short, a [Peer ID](understanding-radicle/glossary.md#peer-id) identifies your device, a [personal
+URN](understanding-radicle/glossary.md#personal-urn) identifies you across devices, and a [project
+URN](understanding-radicle/glossary.md#project-urn) identifies individual repositories of code.
 
-You can create multiple identities using `rad auth`.
+You can always find your Peer ID and personal URN with `rad self`, or create multiple identities with `rad auth --init`
+and switch between them using `rad auth`.
 
-## What's a personal URN?
-
-A **personal URN** which identifies your project on the Radicle network. You can use these URNs to find a project on the
-Radicle [web client](https://app.radicle.network/) or clone a project with `rad clone`.
-
-If you want to share your project with a collaborator, make sure you share its URN.
+If you're sharing a project with a collaborator, all you need is the project URN, which helps others find your project
+on the Radicle [web client](https://app.radicle.network/) or to clone it with `rad clone`. To find your project URN, use `rad ls` or `cd` into the repository and run `rad .`
 
 ## Can I use Radicle with multiple devices?
 

--- a/docs/understanding-radicle/glossary.md
+++ b/docs/understanding-radicle/glossary.md
@@ -14,13 +14,9 @@ spread information between each other via [gossip][gp].
 ## contributor
 A [peer][pe] who has pushed code to a [project][pr].
 
-<!-- ## Device ID
-The encoding of a [peer][pr]'s public key tied to their device. Right now, there
-can only be one Device ID per user (See [Data Model][hiw-dm]) -->
-
 ## display name
-A non-unique human-readable name chosen by an Radicle [user][us]. Like a
-"nickname" for someone's [Radicle ID][ri]. This will be possible to change in
+A non-unique human-readable name chosen by a Radicle [user][us]. Like a
+"nickname" for someone's [Peer ID](#peer-id). This will be possible to change in
 the future.
 
 ## follow
@@ -79,7 +75,7 @@ A unique identifier that allows you to register a permanent name with our opt-in
 
 ## project
 A [project][pr] consists of source code, issues, and proposed changesets. It
-carries a unique, shareable [Radicle ID][ri]. A [project][pr] also includes the
+carries a unique, shareable [project URN](#project-urn). A [project][pr] also includes the
 identities of all its [maintainers][ma]. The entirety of the [project][pr] data
 and metadata, including social artifacts such as comments, are stored within the
 [project][pr]'s repository on the user's machine. [Project][pr]s are the
@@ -97,10 +93,6 @@ with `user-name/project-name`. Required for sharing a project with collaborators
 ## publish
 To make data public to the network. Once something is published, it may be
 fetched and replicated by connected peers.
-
-<!-- ## Radicle ID
-A unique shareable identifier for projects in the Radicle Network. Radicle IDs
-are usually shared as URNs. -->
 
 ## Radicle Link
 A peer-to-peer replication protocol built on Git. See [How it Works][hiw].

--- a/docs/understanding-radicle/glossary.md
+++ b/docs/understanding-radicle/glossary.md
@@ -14,12 +14,12 @@ spread information between each other via [gossip][gp].
 ## contributor
 A [peer][pe] who has pushed code to a [project][pr].
 
-## Device ID
+<!-- ## Device ID
 The encoding of a [peer][pr]'s public key tied to their device. Right now, there
-can only be one Device ID per user (See [Data Model][hiw-dm])
+can only be one Device ID per user (See [Data Model][hiw-dm]) -->
 
 ## display name
-A non-unique human-readable name chosen by an Upstream [user][us]. Like a
+A non-unique human-readable name chosen by an Radicle [user][us]. Like a
 "nickname" for someone's [Radicle ID][ri]. This will be possible to change in
 the future.
 
@@ -67,6 +67,16 @@ to fetch and push changesets to the Radicle network.
 ## peer
 A device running the Radicle Link protocol.
 
+## peer ID
+
+Part of your identity on the Radicle network. It identifies your device, a non-unique [display
+name](#display-name) and the code you publish on the Radicle network, and is secured with an
+Ed25519 keypair.
+
+## personal URN
+
+A unique identifier that allows you to register a permanent name with our opt-in integration with the Ethereum network.
+
 ## project
 A [project][pr] consists of source code, issues, and proposed changesets. It
 carries a unique, shareable [Radicle ID][ri]. A [project][pr] also includes the
@@ -79,13 +89,18 @@ principle unit of replication.
 A human-readable name that is chosen for a [project][pe]. It is not guaranteed
 to be unique.
 
+## project URN
+
+A unique identifier for a specific project on the Radicle network, roughly akin to the way GitHub identifies projects
+with `user-name/project-name`. Required for sharing a project with collaborators and cloning.
+
 ## publish
 To make data public to the network. Once something is published, it may be
 fetched and replicated by connected peers.
 
-## Radicle ID
+<!-- ## Radicle ID
 A unique shareable identifier for projects in the Radicle Network. Radicle IDs
-are usually shared as URNs.
+are usually shared as URNs. -->
 
 ## Radicle Link
 A peer-to-peer replication protocol built on Git. See [How it Works][hiw].
@@ -95,8 +110,7 @@ The network of peers that replicate and gossip data with Radicle Link.
 
 ## Radicle Upstream
 An open-source desktop application (graphic [user][us] interface, GUI) built to
-interact with and enable access to the Radicle Network and, initially, the
-primary end-[user][us] experience. However, in the future, it will be one of
+interact with and enable access to the Radicle network. However, in the future, it will be one of
 many potential clients that [user][us]s can use to access the Radicle network.
 
 ## remote

--- a/docs/understanding-radicle/how-it-works.md
+++ b/docs/understanding-radicle/how-it-works.md
@@ -192,9 +192,7 @@ rules as per [RFC8141][r8] apply.
 An example of a Radicle URN:
 `rad:git:hnrkmzko1nps1pjogxadcmqipfxpeqn6xbeto`.
 
-In the Upstream client, Radicle URNs are called [**Radicle IDs**][ri].
-
-Read more [here][ur]
+<!-- In the Upstream client, Radicle URNs are called [**Radicle IDs**][ri]. -->
 
 
 ### Delegations
@@ -268,7 +266,7 @@ There are four levels of validity:
 ### Overview
 
 Radicle basically uses Git as a database. This means everything is stored in a
-single Git monorepo that is read and written from via the Upstream client. Our
+single Git monorepo that is read and written from via a Radicle client, like the CLI. Our
 Git implementation was devised to create an incentive for the seeder to provide
 all data necessary to resolve and verify a repository, while reducing latency by
 eliminating gossip queries and git fetches as much as possible.
@@ -435,8 +433,7 @@ call this `checking out`.
 ```
 In addition to this, we can see the branches of tracked peers by running `git
 branch`. To provide a human-readable view of a project's remotes, when fetching
-we inspect the `rad/self` identity metadata in order to find nicknames
-(designated via Upstream client). This is managed entired by `librad`, which
+we inspect the `rad/self` identity metadata in order to find nicknames. This is managed entirely by `librad`, which
 reduces to the following in the working copy's config:
 
 ```rust
@@ -474,7 +471,7 @@ The unit of replication is a repository, identified by a `PeerID` in the context
 of a project document (See [Data Model][dm]). The holder of the corresponding
 `DeviceKey` is referred to as the **maintainer** of the repository. Repositories
 belonging to the same project are represented locally as a single repository,
-identified by a Radicle URN (or [Radicle ID][ru] in the Upstream client). In the
+identified by a Radicle URN. In the
 context of a project, the maintainer of a repository may choose to track the
 repositories of other peers (this is called a remote in git terminology: a named
 reference to a remote repository). If the remote repository is found to track
@@ -487,8 +484,7 @@ remotes (i.e. via which tracked PeerID another PeerID is tracked).
 ### Tracking
 Tracking is the backbone of collaboration as it drives the exchange of projects
 and their artifacts. In Radicle, peers track other peers and projects that they
-are interested in. This happens when a peer clones another peer's project or
-tracks a peer directly by adding them as a remote to their project via Upstream.
+are interested in. This happens when a peer clones another peer's project.
 
 Since peers represent seperate devices in the network, they each have their own
 view of the network. Each peer tracks this view of projects, identities, and
@@ -555,9 +551,6 @@ monorepo to track a specific `PEER_ID`. Using the `track` function with
 updates from the tracked peer can be similarly fetched and applied the tracking
 peer's monorepo.
 
-The [`Manage Remotes`][mr] feature in Upstream uses the `track` function to add
-peers as remotes directly to the project.
-
 #### The Social Graph
 
 In the case of multiple peer replications, any peer that tracks a project will
@@ -610,11 +603,11 @@ paths leading back to them, such that contributions can flow back up even if
 they come from participants not within the set of tracked repositories of a
 maintainer.
 
-Upstream is preconfigured with an official Radicle seed node to bootstrap your
+<!-- Upstream is preconfigured with an official Radicle seed node to bootstrap your
 connectivity. If you have removed the default seed node, you can always re-add
 it later by following the steps in [Adding a seed node][gs].
 
-If you're interested in running a seed node, see [Running a seed node][rs].
+If you're interested in running a seed node, see [Running a seed node][rs]. -->
 
 
 ## Collaboration Model
@@ -625,9 +618,9 @@ means that the respective delegates' histories may diverge in their _commit_
 histories, but still converge to an agreement on the validity of the attested
 document revision.
 
-This means that there isn't a single canonical branch (or `master`) in Upstream,
+This means that there isn't a single canonical branch (or `master`),
 as peers are all maintaining their own upstreams of the same project. However,
-due to the data model of Radicle idenities, there will always be a 'canonical'
+due to the data model of Radicle identities, there will always be a 'canonical'
 view of a project associated with its **maintainers**. Maintainers can follow a
 leader-based workflow in which they are converging histories of contributing
 peers into their main branch. Since their view is verifiable and implicitly

--- a/docs/understanding-radicle/how-it-works.md
+++ b/docs/understanding-radicle/how-it-works.md
@@ -192,9 +192,6 @@ rules as per [RFC8141][r8] apply.
 An example of a Radicle URN:
 `rad:git:hnrkmzko1nps1pjogxadcmqipfxpeqn6xbeto`.
 
-<!-- In the Upstream client, Radicle URNs are called [**Radicle IDs**][ri]. -->
-
-
 ### Delegations
 
 As described in [Data Model][dm] Radicle Link distinguishes two types of
@@ -602,13 +599,6 @@ note that, by tracking a seed, upstream maintainers can increase the number of
 paths leading back to them, such that contributions can flow back up even if
 they come from participants not within the set of tracked repositories of a
 maintainer.
-
-<!-- Upstream is preconfigured with an official Radicle seed node to bootstrap your
-connectivity. If you have removed the default seed node, you can always re-add
-it later by following the steps in [Adding a seed node][gs].
-
-If you're interested in running a seed node, see [Running a seed node][rs]. -->
-
 
 ## Collaboration Model
 

--- a/docs/understanding-radicle/troubleshooting.md
+++ b/docs/understanding-radicle/troubleshooting.md
@@ -13,7 +13,7 @@ In the event that this information doesn't resolve your issue, we encourage you 
 [forum](https://radicle.community). If you know which Radicle project is most relevant to your issue, you can also
 create an issue in the appropriate [repository on GitHub](https://github.com/radicle-dev).
 
-If you're having issues using Git, see the [Working with Git][wg] category of this section.
+<!-- If you're having issues using Git, see the [Working with Git][wg] category of this section.
 
 For our known failures, we categorise them with a PascalCase code word that
 gives a high level idea of what went wrong. When you encounter one of these
@@ -177,10 +177,6 @@ case.
 Please report these errors to [GitHub][gi] with as much detail as possible —
 checking first that it's not already reported by another user.
 
-<!--
-TODO(finto): Link to our monorepo explanation
--->
-
 # Working with Git
 
 This section will try to resolve common errors you may run into while trying to
@@ -236,7 +232,7 @@ directory it needs to access for your identity specific data.
 The `active_profile` file can be found under
 `$XDG_CONFIG_HOME/radicle-link/active_profile`.
 Stop the app _before_ removing the file. When you start it up again, the app
-should automatically begin with the onboarding screen to create a new identity.
+should automatically begin with the onboarding screen to create a new identity. -->
 
 [di]: glossary#device-id
 [gs]: getting-started.md

--- a/docs/understanding-radicle/troubleshooting.md
+++ b/docs/understanding-radicle/troubleshooting.md
@@ -8,10 +8,23 @@ the best experience possible. Also, as the developers, we know that there will b
 these diametrically opposed pieces of knowledge, we will try and document any of the errors that we are aware of and
 provide some troubleshooting advice.
 
-In the event that this information doesn't resolve your issue, we encourage you to submit a formal request through the
-**#support** channel on our [Discord server](https://discord.gg/j2HZCBDUvF) or in the **Support** category of our
-[forum](https://radicle.community). If you know which Radicle project is most relevant to your issue, you can also
-create an issue in the appropriate [repository on GitHub](https://github.com/radicle-dev).
+## I ran into a issue — where can I report it?
+
+We suggest you send your report through the **#support** channel on our [Discord server](https://discord.gg/j2HZCBDUvF)
+or in the **Support** category of our [forum](https://radicle.community). A member of the Radicle team will try resolve
+your issue right away, and if they can't, work with you on creating a formal issue/request.
+
+If you know which Radicle project is most relevant to your issue, you can also create an issue in the appropriate
+[repository on GitHub](https://github.com/radicle-dev).
+
+## I need some help — where do I reach out?
+
+You will get the fastest response in the **#support** channel on our [Discord server](https://discord.gg/j2HZCBDUvF).
+
+## How do I join your Matrix channel?
+
+Head over to [matrix.radicle.community](https://matrix.radicle.community/) and create an account. Our Matrix rooms are
+synced with our #general and #support channels on Discord, so you'll always see the same information.
 
 ## Install Radicle CLI on Apple Silicon
 

--- a/docs/understanding-radicle/troubleshooting.md
+++ b/docs/understanding-radicle/troubleshooting.md
@@ -13,235 +13,37 @@ In the event that this information doesn't resolve your issue, we encourage you 
 [forum](https://radicle.community). If you know which Radicle project is most relevant to your issue, you can also
 create an issue in the appropriate [repository on GitHub](https://github.com/radicle-dev).
 
-<!-- If you're having issues using Git, see the [Working with Git][wg] category of this section.
+## Install Radicle CLI on Apple Silicon
 
-For our known failures, we categorise them with a PascalCase code word that
-gives a high level idea of what went wrong. When you encounter one of these
-errors you will receive a notification in the application which allows you to
-copy the error output. The code will be included in this JSON data.
+To build the Radicle CLI on Apple Silicon, you need to be able to install x86_64 Homebrew packages, which means
+installing Homebrew to the `/usr/local` location previously used by Intel systems instead of the default `/opt/homebrew`
+for Apple Silicon systems.
 
-![Error with copy to clipboard button][er]
+The Radicle team is still working on simplifying this installation process — we'd love to hear
+[feedback](get-involved/community.md) on your experiences!
 
-The next sections will start with the header of the code, followed by a reason
-for the error, and perhaps a way to mitigate the error and get you back on track
-with enjoying your Radicle experience.
+> See this [GitHub Gist](https://gist.github.com/sebastinez/d8f2d4979cad0d9f23c162702cdd4735) for more instructions, or
+this [post on installing multiple versions of
+Homebrew](https://medium.com/mkdir-awesome/how-to-install-x86-64-homebrew-packages-on-apple-m1-macbook-54ba295230f) and
+setting up aliases for a more advanced configuration.
 
-## SessionFetchFailure
-#### Reason
-
-The app failed to log into the backend process that manages the peer-to-peer
-network. This might indicate that your identity in the network was not properly
-created or that your on-disk state became corrupted.
-
-#### Action
-Since the cause of this error is most likely corrupted data you should reach out
-to us on [radicle.community][rc] so we can help you solve the issue.
-
-
-## ProjectRequestFailure
-
-### DefaultBranch
-#### Reason
-
-During creation or replication of a project, the default branch was not created
-or fetched. This will result in the application not being able to browse the
-specific project.
-
-#### Action
-
-**Caution**: this advice involves inspecting the state and manually deleting
-some references. Be careful when attempting to apply this fix. If you are at all
-unsure then reach out to us on the previously mentioned channels.
-
-In the error you will spot that the `urn` of the project is in the JSON data.
-The suffix after `rad:git` will correspond to the namespace of the project — see
-[here][mo] for more details.
-
-Your monorepo will live under `$XDG_DATA_HOME/radicle-link/<active_profile_id>/git`. Running the
-following command you should see something like:
+First, install Rosetta 2.
 
 ```
-$ tree $XDG_DATA_HOME/radicle-link/*/git/refs
-
-/home/user/.local/share/radicle-link/d9a6c997-c481-4e0b-888f-6b0e30792458/git/refs/
-├── heads
-├── namespaces
-│   ├── hwd1yre8ibmso5webrog7uqwcrys4fmdijcyjfoso73utnz7y41dbtqudxe
-│   │   └── refs
-│   │       └── rad
-│   │           ├── id
-│   │           ├── self
-│   │           └── signed_refs
-│   └── hwd1yredpofbnmb6d8ea4ofqu31fzziho8xoejjcd15p553fyr4msmg4k8w
-│       └── refs
-│           ├── heads
-│           │   └── main
-│           └── rad
-│               ├── id
-│               ├── ids
-│               │   └── hwd1yre8ibmso5webrog7uqwcrys4fmdijcyjfoso73utnz7y41dbtqudxe
-│               ├── self
-│               └── signed_refs
-└── tags
+$ /usr/sbin/softwareupdate --install-rosetta
 ```
 
-The suffix we pointed out earlier should correspond to one of these entries. In
-this error case the `refs/heads/main` will be missing.
-
-If you just **replicated** the project, then delete this namespace entry and try
-replicate again.
-
-If you just **created** the project, then navigate to your working copy and do
-the following:
+Next, install an Intel-friendly version of Homebrew:
 
 ```
-$ git checkout -b <default branch>
+$ arch -x86_64 zsh
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-Add a `README.md` and commit this to the `<default branch>`, then:
+Finally, install the Radicle CLI to the Intel-based Homebrew.
 
 ```
-$ git push rad <default branch>
+$ brew tap radicle/cli https://seed.alt-clients.radicle.xyz/radicle-cli-homebrew.git
+$ brew install radicle/cli/core
 ```
 
-### Stats
-#### Reason
-
-The [browser][rs] for the project could not fetch the statistics for your
-project.
-
-This could be down to an error in git.
-
-#### Action
-
-Reach out to us on one of our channels, mention the `Stats` code, and provide as
-much detail as possible.
-
-### SignedRefs
-#### Reason
-
-`signed-refs` are the git references that peers advertise which they have also
-signed with their secret key. This means that when your peer receives
-`signed-refs` it attempts to verify the signature using the advertised [Device
-ID][di]. If this verification fails, then this project may be left in a broken
-state.
-
-#### Action
-
-Some of these cases may not be errors and the `signed-refs` did not actually
-come from that Device ID. If you think this is indeed an error, then we can
-attempt to inspect the `signed-refs`.
-
-To get the JSON data for the `signed-refs` we must run the following commands,
-filling in the details for your particular project and remote.
-
-```
-$ cd $XDG_DATA_HOME/radicle-link/<active_profile_id>/git
-
-$ git ls-tree refs/namespaces/<id>/refs[/remotes/<peer>]/rad/signed_refs
-100644 blob e3f6e6bd25955802060698f5b5449c874969aa71    refs
-
-$ git cat-file -p e3f6e6bd25955802060698f5b5449c874969aa71
-{"refs":{"heads":{},"remotes":{}},"signature":"hyydp6mkwkrx1cuz8i4pg3wfojujxaa3s81higa846msaroegcdspp3qe358wmpa3f85s6zmyha5zfgtqnkszwcc6a3k7pfd35fnceoec"}
-```
-
-If you report this JSON payload and the offending Device ID, we can take a look
-and see if we notice anything out of the ordinary.
-
-## BackendTerminated
-### Reason
-
-The app runs a backend process in the background that handles networking and
-file system access. The error indicates that this process was either killed by
-the user or the system or crashed.
-
-### Action
-
-The first thing you can do is try to restart the app which will restart the
-backend process. If the problem persists, the logs from the process might tell
-you what the issue is and give you an idea how you might fix it. For example,
-another process may be listening on the port we’re using or the backend does not
-have the permissions to write to a certain directory.
-
-If you’re not able to fix the problem, please open an [issue on GitHub][gi].
-
-## UnknownException
-### Reason
-
-This is catch all error. As we categorise our errors more & more — and even
-better, eliminate them! — then we should see less & less of this particular
-case.
-
-### Action
-
-Please report these errors to [GitHub][gi] with as much detail as possible —
-checking first that it's not already reported by another user.
-
-# Working with Git
-
-This section will try to resolve common errors you may run into while trying to
-interact with Radicle as a remote.
-
-### Radicle remote helper not configured correctly
-If you try to `git fetch` or `git push rad` without first adding the Radicle
-remote helper to your shell configuration, you'll recieve an error similar to
-the following:
-
-```
-git: 'remote-rad' is not a git command. See 'git --help'.
-```
-
-To make sure you can fetch or push changes you need to add the `git-rad-remote`
-helper to your `$PATH` by adding the following to your shell configuration:
-
-```
-$ export PATH=$PATH:$HOME/.radicle/bin
-```
-
-This custom remote helper ensures that commits are verified by a peer when you
-interact with the Radicle network. For more instructions on how to do this, see
-[Getting Started][gs].
-
-
-**Note** that the `git-rad-remote` helper was included with your installation of
-**Radicle Upstream** and lives under `$HOME/.radicle/bin`.
-
-### Radicle does not prompt for password
-Every git command interacting with the rad remote prompts you for the password.
-It does so via git which relies on the `SSH_ASKPASS` environment variable.
-If you have that variable broken you won't get prompted for a password and see:
-```
-Error: Error unsealing key: Unable to decrypt secret box using the derived key
-```
-**Note**: this is also the error message for entering a wrong password.
-
-You can solve the issue by fixing your `SSH_ASKPASS`. One nice trick can be
-to have a wrapper like `pass show radicle-password` in `~/bin/print-radicle-pw`
-and then use `SSH_ASKPASS=print-radicle-pw git push rad`.
-
-# Lost Passphrase
-
-**Caution**: this advice involves manually deleting a file created by radicle.
-If you are at all unsure then reach out to us on the previously mentioned channels.
-
-If you lost your passphrase for your radicle identity, there is currently no way
-to restore it.
-To start with a new identity, you need to delete the `active_profile` file.
-This file stores the `active_profile_id` that points radicle to the profile aka
-directory it needs to access for your identity specific data.
-The `active_profile` file can be found under
-`$XDG_CONFIG_HOME/radicle-link/active_profile`.
-Stop the app _before_ removing the file. When you start it up again, the app
-should automatically begin with the onboarding screen to create a new identity. -->
-
-[di]: glossary#device-id
-[gs]: getting-started.md
-[mo]: understanding-radicle/how-it-works.md
-[wg]: #working-with-git
-
-[er]: /img/error.png
-
-[gi]: https://github.com/radicle-dev/radicle-upstream/issues
-[rc]: https://radicle.community/c/help
-[rs]: https://github.com/radicle-dev/radicle-surf
-[sc]: https://matrix.to/#/#support:radicle.community

--- a/docs/understanding-radicle/troubleshooting.md
+++ b/docs/understanding-radicle/troubleshooting.md
@@ -3,16 +3,15 @@ id: troubleshooting
 title: Troubleshooting
 ---
 
-As the developers of Upstream we want you, the user, to have the best experience
-possible. Also, as the developers of Upstream, we know that there will be bugs
-and errors in our Beta release. To help consolidate these diametrically opposed
-pieces of knowledge, we will try and document any of the errors that we are
-aware of and provide some troubleshooting advice.
+As the team behind the various protocols and projects that utilize the Radicle network, we want you, the user, to have
+the best experience possible. Also, as the developers, we know that there will be bugs and errors. To help consolidate
+these diametrically opposed pieces of knowledge, we will try and document any of the errors that we are aware of and
+provide some troubleshooting advice.
 
-In the event that this information doesn't resolve your issue, we encourage you
-to submit a formal request through our [#support channel][sc] on our Matrix
-server, in the [Support category][rc] of our radicle.community forum, or [open
-an issue][gi] on GitHub.
+In the event that this information doesn't resolve your issue, we encourage you to submit a formal request through the
+**#support** channel on our [Discord server](https://discord.gg/j2HZCBDUvF) or in the **Support** category of our
+[forum](https://radicle.community). If you know which Radicle project is most relevant to your issue, you can also
+create an issue in the appropriate [repository on GitHub](https://github.com/radicle-dev).
 
 If you're having issues using Git, see the [Working with Git][wg] category of this section.
 


### PR DESCRIPTION
This PR follows up on #165 to remove a few extra references to Upstream from the FAQ, glossary, and troubleshooting docs. It also adds few new definitions for things like Seed IDs and project URNs.