### PR TITLE
getting-started: lock rad-cli client to docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ stored on a Radicle seed node. Make sure you have
 then run:
 
 ```
-$ cargo install radicle-cli --force --locked --git https://seed.alt-clients.radicle.xyz/radicle-cli.git
+$ cargo install radicle-cli --force --locked --git https://github.com/radicle-dev/radicle-cli.git --tag v0.6.1
 ```
 
 When finished, you'll be able to use the `rad` command for managing projects and interacting with the Radicle network.


### PR DESCRIPTION
Docs should recommend installing the version of the rad client the documentation is made for.

Many users are installing the latest unstable version for which the docs are incompatible with.