### PR TITLE
Add guide: Migrate from GitHub to Radicle

### DIFF
--- a/docs/get-involved/community.md
+++ b/docs/get-involved/community.md
@@ -21,17 +21,16 @@ announcements, releases, feature updates, and more.
 
 ## [Twitter](https://twitter.com/radicle)
 
-We use Twitter to share announcements & project-wide updates, as well as amplify Radicle-aligned messaging from
+We use Twitter to share announcements and project-wide updates, as well as amplify Radicle-aligned messaging from
 partnerships and the greater ecosystem. We don't offer support here.
 
 [@radicle](https://twitter.com/radicle)
 
 ## [GitHub](https://github.com/radicle-dev)
 
-GitHub
-
-All Radicle development is open-source and public by default. The radicle-dev GitHub account is consistently active and
-is the best place to see what the team is working on.
+All Radicle development is open-source and public by default. The `radicle-dev` GitHub account is consistently active
+and is the best place to see what the team is working on until Radicle itself has features like issues, patches, and
+CI/CD.
 
 [github.com/radicle-dev](https://github.com/radicle-dev)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,18 +4,14 @@ title: Get started
 sidebar_label: Get started
 ---
 
-import Highlight from '@site/src/components/Highlight'
+import Installation from '@site/src/components/Installation'
 
 Hosting and collaborating on code in Radicle relies on our CLI tooling and your identity.
 
 The CLI tooling is your bridge between Git and the Radicle network, while your identity allows you to host and
 collaborate on projects with your unique identifiers.
 
-<Highlight>
-
-  See the **[Radicle website](https://radicle.xyz/get-started.html)** for the most up to date installation instructions for macOS and Linux, including the process for creating your Radicle identity.
-
-</Highlight>
+<Installation />
 
 > If you have trouble with installation, check out our [troubleshooting guide](troubleshooting.md). You can also find
 > additional instructions, such as installing from source, in the [`radicle-cli`

--- a/docs/migrate-github-radicle.mdx
+++ b/docs/migrate-github-radicle.mdx
@@ -1,0 +1,139 @@
+---
+id: migrate-github-radicle
+title: Migrate from GitHub to Radicle
+sidebar_label: Migrate from GitHub to Radicle
+---
+
+import Installation from '@site/src/components/Installation'
+
+Welcome to Radicle&mdash;software that enables developers to securely collaborate on software over a peer-to-peer
+network built on Git. Check out our homepage if you haven't already seen our comparison between [Radicle and
+alternatives like GitHub or GitLab](https://radicle.xyz/).
+
+Assuming you're already onboard Radicle's vision of sovereign code infrastructure, let's talk about what we'll cover.
+With this guide, you'll:
+
+- Create a Radicle identity.
+- Migrate your code hosting to Radicle's network.
+- Continue pushing changes to Radicle alone, or mirror changes in both Radicle and GitHub.
+
+:::info
+
+Radicle doesn't yet have feature parity with GitHub&mdash;we're still working on visual code reviews, an issue board,
+and CI/CD pipelines. Even you _need_ these features, stopping you from migrating in full, we still encourage you to
+migrate your project to Radicle and mirror your changes so that you can quickly make the switch when the time is right!
+
+:::
+
+## Install the Radicle CLI
+
+To migrate from GitHub to Radicle, you first need to install the Radicle CLI and create a Radicle identity, which is
+like creating an account on GitHub. It's how your projects are identified on the Radicle network, and it's your key to
+hosting code and collaborating with others on your project.
+
+<Installation />
+
+Once you're done with the first two steps&mdash;**Install the Radicle `rad` CLI.** and **Run rad auth to create your
+Radicle identity.**&mdash;you can return here for the rest of the instructions.
+
+## Initialize your project on Radicle
+
+Radicle wraps around the `git` binary and processes you already use to manage your project's data and history. This
+rapper lets you push your code to the sovereign Radicle network and collaborate with others.
+
+Because you already have a project you've pushed to GitHub, you already initialized the Git repository with `git init`,
+which created the `.git` directory to store objects, heads, refs, and more.
+
+Initializing a project on Radicle is as simple as setting up Git for the first time:
+
+```
+cd your-project-directory/
+rad init
+```
+
+Add a description and choose your default branch, which is typically either `main` or `master`.
+
+Running `rad init` does two things:
+
+- Creates a unique peer-to-peer identity&mdash;a project URN&mdash;for your project.
+- Adds a new `remote` to your project's existing configuration using that new identity, for pushing code to a unique
+  address on the Radicle network.
+
+You'll also see a line similar to `ok Project initialized: rad:git:hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo`. The text
+after `rad:git:` is your project's URN.
+
+You can always find your project's URN by running `rad .` from the project's directory.
+
+## Push to the Radicle network
+
+You can push to the network now that you've initialized your project on Radicle. Assuming you have no unstaged changes
+in your repository, you're ready to push.
+
+```
+rad push
+```
+
+Since this is your first push to Radicle, the CLI asks which seed node you want to sync with. Radicle provides three
+seed nodes with _identical_ functionality&mdash;`pine`, `willow`, and `maple`.
+
+Choose wisely!
+
+:::tip
+
+You can also sync to multiple Radicle-hosted seed nodes, or [host your own seed
+node](https://github.com/radicle-dev/radicle-client-services), if you'd like additional resiliency or security.
+
+:::
+
+Once `rad` pushes your project to the Radicle network, it outputs details on where you can find your project on the
+[Radicle web app](https://app.radicle.xyz).
+
+```
+🌱 Your project is synced and available at:
+
+    (web) https://app.radicle.xyz/seeds/willow.radicle.garden/rad:git:hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo/
+    (git) https://willow.radicle.garden/hnrkqi6ohci9m59i54ppiy3fqkedkjt98ymdo.git
+```
+
+### Push to both Radicle and GitHub simultaneously (mirror)
+
+If you're not ready to migrate away from GitHub completely, you can mirror your project in both places.
+
+```
+git add .
+git commit -m "Your commit message here"
+rad push
+git push
+```
+
+If you don't like running two commands, you could also create an alias in Zsh or Bash to automate the process. Edit your
+`~/.zshrc` or `~/.bash_profile` file and add the following line, which first pushes to your existing remote on GitHub
+and Radicle in sequence when you run `gp`.
+
+```
+alias gp="rad push && git push"
+```
+
+## Code collaboration on Radicle (issues and patches/PRs)
+
+Certain features, like visual code reviews and issue discussion boards, aren't yet live on Radicle.
+
+We're prioritizing must-have features like issues and patches, with more information coming soon.
+
+For now, the best way to collaborate is to have each contributor [clone](using-radicle/clone.md) the project, [push
+changes](using-radicle/push.md) to their remotes, and have a single maintainer responsible for [tracking, reviewing, and
+merging](using-radicle/track-review-merge.md) changes to keep the project and contributors in sync.
+
+## What's next?
+
+If you're having trouble with any part of the migration process, check out our [troubleshooting
+guide](understanding-radicle/troubleshooting.md), or head over to the [**#support** channel on
+Discord](https://discord.gg/j2HZCBDUvF), where a member of the Radicle team will help you out.
+
+The next best thing you can do is [share your project](using-radicle/view-share.md) with collaborators so they can
+[clone](using-radicle/clone.md) it and push their changes, completing your migration away from not just GitHub, but all
+centralized, online-first, and censorship-prone code hosting platforms.
+
+Now that you're on the Radicle network, hop into our [Discord server](https://discord.gg/j2HZCBDUvF), where our core
+team and collaborators actively chat about the future of sovereign code infrastructure, what we're working on next, and
+ways to get involved.

--- a/docs/migrate-github-radicle.mdx
+++ b/docs/migrate-github-radicle.mdx
@@ -30,9 +30,9 @@ right!
 
 ## Install the Radicle CLI
 
-To migrate from GitHub to Radicle, you first need to install the Radicle CLI and create a Radicle identity, which is
-like creating an account on GitHub. It's how your projects are identified on the Radicle network, and it's your key to
-hosting code and collaborating with others on your project.
+To migrate from GitHub to Radicle, you first need to install the Radicle CLI and create a Radicle
+[identity](using-radicle/identity.md), which is like creating an account on GitHub. It's how your projects are
+identified on the Radicle network, and it's your key to hosting code and collaborating with others on your project.
 
 <Installation />
 
@@ -128,11 +128,13 @@ For now, the best way to collaborate is to have each contributor [clone](using-r
 changes](using-radicle/push.md) to their remotes, and have a single maintainer responsible for [tracking, reviewing, and
 merging](using-radicle/track-review-merge.md) changes to keep the project and contributors in sync.
 
+You can also [create, view, and comment on issues](using-radicle/issues.md) using the CLI.
+
 ## What's next?
 
 If you're having trouble with any part of the migration process, check out our [troubleshooting
-guide](understanding-radicle/troubleshooting.md), or head over to the [**#support** channel on
-Discord](https://discord.gg/j2HZCBDUvF), where a member of the Radicle team will help you out.
+guide](troubleshooting.md), or head over to the [**#support** channel on Discord](https://discord.gg/j2HZCBDUvF), where
+a member of the Radicle team will help you out.
 
 The next best thing you can do is [share your project](using-radicle/view-share.md) with collaborators so they can
 [clone](using-radicle/clone.md) it and push their changes, completing your migration away from not just GitHub, but all

--- a/docs/migrate-github-radicle.mdx
+++ b/docs/migrate-github-radicle.mdx
@@ -17,6 +17,8 @@ With this guide, you'll:
 - Migrate your code hosting to Radicle's network.
 - Continue pushing changes to Radicle alone, or mirror changes in both Radicle and GitHub.
 
+This guide also works if you're currently using GitLab, Gitea, or any other Git-based code hosting platform.
+
 :::info
 
 Radicle doesn't yet have feature parity with GitHub&mdash;we're still working on visual code reviews, an issue board,

--- a/docs/migrate-github-radicle.mdx
+++ b/docs/migrate-github-radicle.mdx
@@ -6,7 +6,7 @@ sidebar_label: Migrate from GitHub to Radicle
 
 import Installation from '@site/src/components/Installation'
 
-Welcome to Radicle&mdash;software that enables developers to securely collaborate on software over a peer-to-peer
+Welcome to Radicle &mdash; software that enables developers to securely collaborate on software over a peer-to-peer
 network built on Git. Check out our homepage if you haven't already seen our comparison between [Radicle and
 alternatives like GitHub or GitLab](https://radicle.xyz/).
 
@@ -21,7 +21,7 @@ This guide also works if you're currently using GitLab, Gitea, or any other Git-
 
 :::info
 
-Radicle doesn't yet have feature parity with GitHub&mdash;we're still working on visual code reviews, an issue board,
+Radicle doesn't yet have feature parity with GitHub &mdash; we're still working on visual code reviews, an issue board,
 and CI/CD pipelines. Even if the lack of these features is stopping you from migrating in full, we still encourage you
 to migrate your project to Radicle and mirror your changes so that you can quickly make the switch when the time is
 right!
@@ -36,8 +36,8 @@ hosting code and collaborating with others on your project.
 
 <Installation />
 
-Once you're done with the first two steps&mdash;**Install the Radicle `rad` CLI.** and **Run `rad auth` to create your
-Radicle identity.**&mdash;you can return here for the rest of the instructions.
+Once you're done with the first two steps &mdash; **Install the Radicle `rad` CLI.** and **Run `rad auth` to create your
+Radicle identity.** &mdash; you can return here for the rest of the instructions.
 
 ## Initialize your project on Radicle
 
@@ -58,7 +58,7 @@ Add a description and choose your default branch, which is typically either `mai
 
 Running `rad init` does two things:
 
-- Creates a unique peer-to-peer identity&mdash;a project URN&mdash;for your project.
+- Creates a unique peer-to-peer identity &mdash; a project URN &mdash; for your project.
 - Adds a new `remote` to your project's existing configuration using that new identity, for pushing code to a unique
   address on the Radicle network.
 
@@ -76,7 +76,7 @@ rad push
 ```
 
 Since this is your first push to Radicle, the CLI asks which seed node you want to sync with. Radicle provides three
-seed nodes with _identical_ functionality&mdash;`pine`, `willow`, and `maple`.
+seed nodes with _identical_ functionality &mdash; `pine`, `willow`, and `maple`.
 
 Choose wisely!
 

--- a/docs/migrate-github-radicle.mdx
+++ b/docs/migrate-github-radicle.mdx
@@ -22,8 +22,9 @@ This guide also works if you're currently using GitLab, Gitea, or any other Git-
 :::info
 
 Radicle doesn't yet have feature parity with GitHub&mdash;we're still working on visual code reviews, an issue board,
-and CI/CD pipelines. Even you _need_ these features, stopping you from migrating in full, we still encourage you to
-migrate your project to Radicle and mirror your changes so that you can quickly make the switch when the time is right!
+and CI/CD pipelines. Even if the lack of these features is stopping you from migrating in full, we still encourage you
+to migrate your project to Radicle and mirror your changes so that you can quickly make the switch when the time is
+right!
 
 :::
 
@@ -35,13 +36,13 @@ hosting code and collaborating with others on your project.
 
 <Installation />
 
-Once you're done with the first two steps&mdash;**Install the Radicle `rad` CLI.** and **Run rad auth to create your
+Once you're done with the first two steps&mdash;**Install the Radicle `rad` CLI.** and **Run `rad auth` to create your
 Radicle identity.**&mdash;you can return here for the rest of the instructions.
 
 ## Initialize your project on Radicle
 
 Radicle wraps around the `git` binary and processes you already use to manage your project's data and history. This
-rapper lets you push your code to the sovereign Radicle network and collaborate with others.
+wrapper lets you push your code to the sovereign Radicle network and collaborate with others.
 
 Because you already have a project you've pushed to GitHub, you already initialized the Git repository with `git init`,
 which created the `.git` directory to store objects, heads, refs, and more.
@@ -68,8 +69,7 @@ You can always find your project's URN by running `rad .` from the project's dir
 
 ## Push to the Radicle network
 
-You can push to the network now that you've initialized your project on Radicle. Assuming you have no unstaged changes
-in your repository, you're ready to push.
+You can push to the network now that you've initialized your project on Radicle.
 
 ```
 rad push
@@ -83,7 +83,9 @@ Choose wisely!
 :::tip
 
 You can also sync to multiple Radicle-hosted seed nodes, or [host your own seed
-node](https://github.com/radicle-dev/radicle-client-services), if you'd like additional resiliency or security.
+node](https://github.com/radicle-dev/radicle-client-services), if you'd like additional resiliency or security. `rad
+push` syncs with your default seed node, which you can find with `git config --local rad.seed`, but you'll need to run
+`rad push --seed <your-seed-node-url>` for each additional seed node you want to sync with.
 
 :::
 

--- a/docs/radicle.md
+++ b/docs/radicle.md
@@ -8,7 +8,7 @@ slug: /
 Radicle is a decentralized code collaboration network built on open protocols 🌱. It enables developers to collaborate
 on code without relying on trusted intermediaries. Radicle was designed to provide similar functionality to centralized
 code collaboration platforms — or "forges" — while retaining Git’s peer-to-peer nature, building on what made
-distributed version control so powerful in the first place. 
+distributed version control so powerful in the first place.
 
 - Instead of user accounts and logins, Radicle uses public key cryptography to identify projects and their
   collaborators.
@@ -18,32 +18,21 @@ distributed version control so powerful in the first place.
 - Instead of dictating your process for collaboration, Radicle lets anyone build new tools or design new workflows
   around completely open protocols.
 
-You get recognizable collaboration flows from centralized code hosting platforms — the "forges" like GitHub and GitLab —
-while also eliminating the reliance and risk on these corporate platforms.
+Two interlacing clients create this experience:
 
-Two interlacing clients create this experience.
-
-1. The **[`rad` command-line
-   tool](https://app.radicle.xyz/alt-clients.radicle.eth/rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao/tree)**, which interacts with Git and the Radicle network to help you host code or collaborate on projects.
+1. The **[`rad` command-line tool](https://github.com/radicle-dev/radicle-cli)**, which interacts with Git and the
+   Radicle network to help you host code or collaborate on projects.
 2. The **[web app](https://app.radicle.xyz)**, which provides a visual interface for discovering projects, viewing
    code, and viewing patches from collaborators.
 
-Apart from **code collaboration**, Radicle also addresses **open source funding** through
-[Drips](https://www.drips.network/), an Ethereum protocol for generating recurring income with subscriptions and NFT
-memberships. Drips helps you create a circular funding network by dripping funds to your favorite creators and
-dedicating a percentage of your incoming drips to others.
+Radicle also addresses **open source funding** through [Drips](https://www.drips.network/), an Ethereum protocol for
+generating recurring income with subscriptions and NFT memberships. Drips helps you create a circular funding network by
+dripping funds to your favorite creators and dedicating a percentage of your incoming drips to others.
 
 ## How do I use Radicle?
 
-Because Radicle is built on open protocols, there will never be *one true way* to do something on the Radicle network.
-
-Instead, this documentation offers an *opinionated* way to take common actions around hosting code on the Radicle
-network and collaborating with others using Radicle-developed projects and interfaces.
-
 > **To start hosting and collaborating on code in the Radicle network, see our [getting started
 > guide](getting-started.md).**
-
-Additional discovery and collaboration features are planned and under active development.
 
 For more help on using Radicle, be sure to join our [community channels](get-involved/community.md).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,7 +8,7 @@ const sidebars = {
       type: 'category',
       label: 'Introduction',
       collapsed: false,
-      items: ['what-is-radicle', 'get-started', 'troubleshooting'],
+      items: ['what-is-radicle', 'get-started', 'migrate-github-radicle', 'troubleshooting'],
     },
     {
       type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,7 +8,12 @@ const sidebars = {
       type: 'category',
       label: 'Introduction',
       collapsed: false,
-      items: ['what-is-radicle', 'get-started', 'migrate-github-radicle', 'troubleshooting'],
+      items: [
+        'what-is-radicle',
+        'get-started',
+        'migrate-github-radicle',
+        'troubleshooting'
+      ],
     },
     {
       type: 'category',

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -1,13 +1,14 @@
 import React from 'react'
 
-export default function Highlight({children}) {
+export default function Highlight ({ children }) {
   return (
     <div
       style={{
-        backgroundColor: '#ebecf8',
-        borderRadius: '0.75rem',
+        backgroundColor: 'rgb(241, 244, 247)',
+        borderColor: '#242e38',
+        borderRadius: '0.5rem',
         marginBottom: '20px',
-        padding: '2rem 2rem calc(2rem - 20px)',
+        padding: '2rem 2rem',
         fontSize: '20px',
         '& p': {
           margin: '0 0 0',

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -4,8 +4,7 @@ export default function Highlight ({ children }) {
   return (
     <div
       style={{
-        backgroundColor: 'rgb(241, 244, 247)',
-        borderColor: '#242e38',
+        border: '1px solid rgba(85, 85, 255, 0.7)',
         borderRadius: '0.5rem',
         marginBottom: '20px',
         padding: '2rem 2rem',

--- a/src/components/Installation.js
+++ b/src/components/Installation.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import Highlight from '@site/src/components/Highlight'
+
+export default function Installation ({ children }) {
+  return (
+    <Highlight>
+      See the <a href="https://radicle.xyz/get-started.html">Radicle website</a> for the most up-to-date installation instructions for macOS and Linux, including the process for creating your Radicle identity.
+    </Highlight>
+  );
+}


### PR DESCRIPTION
As the title suggest, this guide covers the bare minimum steps one needs to migrate from GitHub—basically, run `rad init` and `rad push`—and then help point them to other docs that flesh out their understanding of the Radicle experience.

Obviously, the content isn't dramatically different from our main [install instructions](https://radicle.xyz/get-started.html), but I think it's important to provide some context and simplify the leap from GitHub to Radicle.