### PR TITLE
New doc: Radicle versus GitHub and GitLab

### DIFF
--- a/docs/understanding-radicle/radicle-versus-github-gitlab.md
+++ b/docs/understanding-radicle/radicle-versus-github-gitlab.md
@@ -4,16 +4,17 @@ title: Radicle versus GitHub and GitLab
 ---
 
 You probably already use GitHub or GitLab for code hosting and collaboration, and we recognize that to convince you to
-migrate to Radicle, you want to know how the products stack up. Let’s talk about how they differentiate in key areas.
+migrate to Radicle, you want to know how the products stack up. Let's talk about how they differ in key areas.
 
-This isn't designed to be a comprehensive feature-by-feature comparison, but rather to provide transparency into the
-core philosophies behind Radicle's continued development of sovereign code infrastructure.
+This isn't designed to be a comprehensive feature-by-feature comparison but to provide transparency into the core
+philosophies behind Radicle's continued development of sovereign code infrastructure.
 
 ## Fundamentals
 
 ### Open source
 
-**Radicle** uses an [open-source stack](https://github.com/radicle-dev) from  top to bottom—there are no “closed” components. Every component of the Radicle stack is auditable, modifiable, and extendable.
+**Radicle** uses an [open-source stack](https://github.com/radicle-dev) from  top to bottom—there are no "closed"
+components. Every component of the Radicle stack is auditable, modifiable, and extendable.
 
 **GitHub** uses proprietary code.
 
@@ -21,80 +22,77 @@ core philosophies behind Radicle's continued development of sovereign code infra
 
 ### Authorship
 
-**Radicle** automatically verifies, through cryptographic keys, all user artifacts, like comments, issues, and code reviews, ensuring you know who you’re collaborating with even if you don’t know their “true” identity.
+**Radicle** automatically verifies all user artifacts, like comments, issues, and code reviews, through cryptographic
+keys, ensuring you know who you're collaborating with even if you don't know their "true" identity.
 
-**GitHub** 
+**GitHub** and **GitLab** support signing code commits with GPG, but not issues, comments, or pull requests.
 
-**GitLab** 
+### Sovereignty
 
-### Sovereign
+**Radicle** user and project identities, plus all metadata, is wholly owned by you. You can always migrate away from a
+Radicle-sponsored seed node to a [self-hosted](https://github.com/radicle-dev/radicle-client-services) one, using all
+the features in a decentralized fashion.
 
-**Radicle** user and project identities, plus all metadata, is completely owned by you.
-
-**GitHub** 
-
-**GitLab** 
+**GitHub** and **GitLab** own your user and project identities. You can clone/mirror your code elsewhere, but you can
+never own the "namespace" that your project exists at (`your-username/your-project`) or its metadata.
 
 ### Distributed
 
-**Radicle** 
+**Radicle** uses multiple seed nodes, and allows anyone to [self-host a seed
+node](https://github.com/radicle-dev/radicle-client-services), to get all of Radicle's features using their own
+infrastructure. In the future, Radicle will also use a peer-to-peer protocol for distributing Git data and Radicle
+identities across users and seed nodes in a cryptographically secure manner.
 
-Radicle is ****not**** global by default. Instead, the social graph of peers and projects you track determines what content you see, interact with, and replicate.
-
-**GitHub** 
-
-**GitLab** 
+**GitHub** and **GitLab** are centralized services. While their infrastructure is distributed across multiple public
+cloud providers and locations for resiliency, your project data and collaboration always goes through their servers.
 
 ### Local-first
 
-**Radicle** 
+**Radicle** can be used offline in perpetuity, with all your project's commit history and Radicle metadata &mdash; such
+as already-pulled issues and patches &mdash; stored locally.
 
-5. Radicle is designed for bazaar-style development. This means that within projects, there isn't a single master branch that contributors merge into. Instead, peers maintain their own views of projects that can be fetched and merged by other peers via patches.
-
-**GitHub** 
-
-**GitLab** 
+**GitHub** and **GitLab** require you to be online to review PRs or collaborate on code.
 
 ### Censorship-resistant
 
-**Radicle** 
+**Radicle** users can't be barred from using Radicle tools, and can't have their projects, code, or accounts deleted at
+a platform level, because one can always [self-host](https://github.com/radicle-dev/radicle-client-services) an
+open-source seed node. In addition, Radicle is a self-sustained and community-owned network &mdash; not a corporation
+&mdash; with governance organized by a token called RAD that lives on Ethereum.
 
-**Radicle is a self-sustained and community-owned network** — not a corporation. It's governance is organized by a token called RAD that lives on Ethereum.
-
-**GitHub** 
-
-**GitLab** 
+**GitHub, Inc.** has been a subsidiary of Microsoft since 2018. **GitLab Inc.** is a publicly-traded corporation. Both
+companies have a verified history of removing repositories, and entire user accounts, in response to DMC takedown
+notices, other legal notices, and government pressure.
 
 ## Features
 
 ### CLI
 
-**Radicle** 
+**Radicle** is CLI-first, with efficient workflows, integrations with your favorite editors, automation, and the ability
+to use other multiple clients for the best experience for you.
 
-**GitHub** 
+**GitHub** offers a CLI experience for listing issues, creating PRs, checking out PRs, and more.
 
-**GitLab** 
+**GitLab** has no CLI tooling.
 
 ### Code collaboration
 
-**Radicle** 
+**Radicle** offers CLI-based code collaboration through multiple remotes (similar to forks), issues, and patches (our
+version of pull requests), with support for viewing issues and patches on the web app coming soon.
 
-**GitHub** 
-
-**GitLab** 
+**GitHub** and **GitLab** web-based management of forks/branches, pull requests, interactive code reviews, and more.
 
 ### CI/CD
 
-**Radicle** 
+**Radicle** is working on CI/CD functionality.
 
-**GitHub** 
+**GitHub** is tightly integrated with GitHub Actions, with integrations for external CI/CD platforms like Jenkins and
+CircleCI.
 
-**GitLab** 
+**GitLab** is tightly integrated with GitLab CI/CD, with integrations for external CI/CD platforms.
 
 ### Private repositories
 
-**Radicle** 
+**Radicle** does not support private repositories.
 
-**GitHub** 
-
-**GitLab**
+**GitHub** and **GitLab** offer repositories that are private to other users, not GitHub or GitLab themselves.

--- a/docs/understanding-radicle/radicle-versus-github-gitlab.md
+++ b/docs/understanding-radicle/radicle-versus-github-gitlab.md
@@ -1,0 +1,100 @@
+---
+id: radicle-versus-github-gitlab
+title: Radicle versus GitHub and GitLab
+---
+
+You probably already use GitHub or GitLab for code hosting and collaboration, and we recognize that to convince you to
+migrate to Radicle, you want to know how the products stack up. Let’s talk about how they differentiate in key areas.
+
+This isn't designed to be a comprehensive feature-by-feature comparison, but rather to provide transparency into the
+core philosophies behind Radicle's continued development of sovereign code infrastructure.
+
+## Fundamentals
+
+### Open source
+
+**Radicle** uses an [open-source stack](https://github.com/radicle-dev) from  top to bottom—there are no “closed” components. Every component of the Radicle stack is auditable, modifiable, and extendable.
+
+**GitHub** uses proprietary code.
+
+**GitLab** uses [open-source code](https://gitlab.com/gitlab-org) across its stack.
+
+### Authorship
+
+**Radicle** automatically verifies, through cryptographic keys, all user artifacts, like comments, issues, and code reviews, ensuring you know who you’re collaborating with even if you don’t know their “true” identity.
+
+**GitHub** 
+
+**GitLab** 
+
+### Sovereign
+
+**Radicle** user and project identities, plus all metadata, is completely owned by you.
+
+**GitHub** 
+
+**GitLab** 
+
+### Distributed
+
+**Radicle** 
+
+Radicle is ****not**** global by default. Instead, the social graph of peers and projects you track determines what content you see, interact with, and replicate.
+
+**GitHub** 
+
+**GitLab** 
+
+### Local-first
+
+**Radicle** 
+
+5. Radicle is designed for bazaar-style development. This means that within projects, there isn't a single master branch that contributors merge into. Instead, peers maintain their own views of projects that can be fetched and merged by other peers via patches.
+
+**GitHub** 
+
+**GitLab** 
+
+### Censorship-resistant
+
+**Radicle** 
+
+**Radicle is a self-sustained and community-owned network** — not a corporation. It's governance is organized by a token called RAD that lives on Ethereum.
+
+**GitHub** 
+
+**GitLab** 
+
+## Features
+
+### CLI
+
+**Radicle** 
+
+**GitHub** 
+
+**GitLab** 
+
+### Code collaboration
+
+**Radicle** 
+
+**GitHub** 
+
+**GitLab** 
+
+### CI/CD
+
+**Radicle** 
+
+**GitHub** 
+
+**GitLab** 
+
+### Private repositories
+
+**Radicle** 
+
+**GitHub** 
+
+**GitLab**

--- a/docs/understanding-radicle/radicle-versus-github-gitlab.md
+++ b/docs/understanding-radicle/radicle-versus-github-gitlab.md
@@ -22,8 +22,9 @@ components. Every component of the Radicle stack is auditable, modifiable, and e
 
 ### Authorship
 
-**Radicle** automatically verifies all user artifacts, like comments, issues, and code reviews, through cryptographic
-keys, ensuring you know who you're collaborating with even if you don't know their "true" identity.
+**Radicle** automatically verifies all user artifacts, like [issues](using-radicle/issues.md) and [code
+reviews](using-radicle/track-review-merge.md), through cryptographic keys, ensuring you know who you're collaborating
+with even if you don't know their "true" identity.
 
 **GitHub** and **GitLab** support signing code commits with GPG, but not issues, comments, or pull requests.
 
@@ -77,8 +78,9 @@ to use other multiple clients for the best experience for you.
 
 ### Code collaboration
 
-**Radicle** offers CLI-based code collaboration through multiple remotes (similar to forks), issues, and patches (our
-version of pull requests), with support for viewing issues and patches on the web app coming soon.
+**Radicle** offers CLI-based code collaboration through multiple remotes (similar to forks),
+[issues](using-radicle/issues.md), and patches (our version of pull requests), with support for viewing issues and
+patches on the web app coming soon.
 
 **GitHub** and **GitLab** web-based management of forks/branches, pull requests, interactive code reviews, and more.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,18 +12,12 @@ const sidebars = {
       label: 'Code hosting',
       collapsed: false,
       items: [
-<<<<<<< HEAD
         'using-radicle/create',
         'using-radicle/view-share',
         'using-radicle/push',
         'using-radicle/clone',
         'using-radicle/identity',
       ]
-=======
-        'what-is-radicle',
-        'get-started',
-      ],
->>>>>>> fd71261 (Finish draft)
     },
     {
       type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,12 +12,18 @@ const sidebars = {
       label: 'Code hosting',
       collapsed: false,
       items: [
+<<<<<<< HEAD
         'using-radicle/create',
         'using-radicle/view-share',
         'using-radicle/push',
         'using-radicle/clone',
         'using-radicle/identity',
       ]
+=======
+        'what-is-radicle',
+        'get-started',
+      ],
+>>>>>>> fd71261 (Finish draft)
     },
     {
       type: 'category',
@@ -33,7 +39,13 @@ const sidebars = {
       type: 'category',
       label: 'Understanding Radicle',
       collapsed: false,
-      items: ['understanding-radicle/why-radicle', 'understanding-radicle/how-it-works', 'understanding-radicle/glossary', 'understanding-radicle/faq']
+      items: [
+        'understanding-radicle/why-radicle',
+        'understanding-radicle/how-it-works',
+        'understanding-radicle/radicle-versus-github-gitlab',
+        'understanding-radicle/glossary',
+        'understanding-radicle/faq',
+      ]
     },
     {
       type: 'category',


### PR DESCRIPTION
This PR expands on the comparison featured on the homepage and provides some additional/richer context for those who are interested. I think it's important to vigorously defend Radicle's choices around sovereignty but also provide transparency into areas where Radicle's features are not 100% on par with GitHub or GitLab.

![image](https://user-images.githubusercontent.com/1153921/191335020-f2821d1a-db85-46bb-8ae2-25a2d8833e99.png)