### PR TITLE
Reduce confusion around seed node selection

### DIFF
--- a/docs/migrate-github-radicle.mdx
+++ b/docs/migrate-github-radicle.mdx
@@ -78,7 +78,7 @@ rad push
 Since this is your first push to Radicle, the CLI asks which seed node you want to sync with. Radicle provides three
 seed nodes with _identical_ functionality &mdash; `pine`, `willow`, and `maple`.
 
-Choose wisely!
+Choose any that you like!
 
 :::tip
 


### PR DESCRIPTION
During the UX studies we've been running with new users, we noticed that the seed node selection actually confuses people. It was common to be met with reactions like "if all 3 seed nodes are run by radicle, why pick one over the others?". 

This will hopefully make it clearer.