### PR TITLE
Update deployed URL and other 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Welcome to Radicle's docs! 👋
 
-This is the repository for the Radicle documentation site at [`docs.radicle.xyz`](https://docs.radicle.xyz), which
-includes user-, community-, and governance-focused documentation.
+This is the repository for the Radicle documentation site at [`docs.radicle.community`](https://docs.radicle.community),
+which includes user-, community-, and governance-focused documentation.
 
 This document outlines some contributing guidelines, contact points, and other resources to make it easier to contribute
 to Radicle's documentation.
 
-[`docs.radicle.xyz`](https://docs.radicle.xyz) was created with [Docusaurus](https://docusaurus.io/).
+[`docs.radicle.community`](https://docs.radicle.community) was created with [Docusaurus](https://docusaurus.io/).
 
 If you run into a problem or have a suggestion, browse the open
 [issues](https://github.com/radicle-dev/radicle-docs/issues) before opening a new one. We use the following [label

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -74,7 +74,7 @@ excuse the dust. 🚧
     See the latest updates and announcements, including snapshot polls and voting reminders, as we transition to the RadicleDAO.
   </Button>
   <Button
-    href="https://www.getrevue.co/profile/radicle"
+    href="https://radicle.beehiiv.com/"
     title="Radicle Digest"
     cta="Subscribe"
   >

--- a/docs/community/calls.md
+++ b/docs/community/calls.md
@@ -307,7 +307,7 @@ Yorgos is looking for “IntelliJ/PhpStorm/PyCharm/Rider/GoLand/RubyMine/WebStor
 
 What’s required to participate:
 
-- (optional - if you don't know about Radicle) Read through some introduction material to help you understand more about it and help you decide if you’re interested. You can try the [Official FAQ](https://docs.radicle.xyz/understanding-radicle/faq), or this [tweetstorm](https://twitter.com/odyslam_/status/1499340092564918275).
+- (optional - if you don't know about Radicle) Read through some introduction material to help you understand more about it and help you decide if you’re interested. You can try the [Official FAQ](https://docs.radicle.community/understanding-radicle/faq), or this [tweetstorm](https://twitter.com/odyslam_/status/1499340092564918275).
 - If you’re still interested, fill in an (anonymous) questionnaire [here](https://research.typeform.com/to/cjE4J0rc).
 - If you’re still interested, you can book a (30min) slot at the final step of the questionnaire above.
 

--- a/docs/governance/calls-notes-recordings.md
+++ b/docs/governance/calls-notes-recordings.md
@@ -2,14 +2,30 @@
 title: Radicle Governance Calls
 ---
 
-The governance team hosts monthly governance calls on [Discord](https://discord.gg/j2HZCBDUvF) to provide an opportunity
+The governance team hosts monthly governance calls on [Discord](https://discord.gg/j2HZCBDUvF) to provide an opportunity
 to discuss current governance proposals, share updates from the governance team, and highlight important discussion
 around the transition to the DAO. This is also a great opportunity to ask questions and communicate ideas or concerns
 around governance of the project.
 
 These calls tend to take place on the second Wednesday of every month. To figure out when the next call is happening,
-check our "Events" section on Discord. We also post reminders for these calls in
-the [#governance-updates](https://discord.com/channels/841318878125490186/955793826264514560) channel. 
+check our **Events** section on Discord. We also post reminders for these calls in
+the [#governance-updates](https://discord.com/channels/841318878125490186/955793826264514560) channel.
 
-[Recordings of all previous Governance Working Group can be found
-here!](https://www.youtube.com/playlist?list=PLUUjDC9sOrpktWjO7jNFwsisK0vi5d_Tx)
+| Date                           | Notes                                                                                                                     | Recording                                                                                                  |
+| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------- |
+| December 17, 2022 @ 17:00 CET  | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-17-December-2022-2b8f9e2da25b4ec7b5283470db11eebc)     | [video](https://youtu.be/7lI-wbXQbAc)                                                                      |
+| November 9, 2022 @ 17:00 CET   | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-16-November-2022-1fba67d44e964c468403ea22e9fc2bb6)     | [video](https://youtu.be/64587Uf-bt4)                                                                      |
+| October 12, 2022 @ 17:00 CET   | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-15-12-October-2022-464cf907955848deacd721d050f7efb0)   | [video](https://www.youtube.com/watch?v=u4gH1KbqPuE&list=PLUUjDC9sOrpktWjO7jNFwsisK0vi5d_Tx&index=12&t=5s) |
+| September 14, 2022 @ 17:00 CET | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-14-14-September-2022-a2caf9ec856b4cfc8dd7e2dc48f4a1ce) | [video](https://www.youtube.com/watch?v=5lZcbxtHORM&list=PLUUjDC9sOrpktWjO7jNFwsisK0vi5d_Tx&index=11)      |
+| August 10, 2022 @ 17:00 CET    | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-13-10-August-2022-9a14ec284ed84594921ebe2c0a8d8515)    | [video](https://www.youtube.com/watch?v=oPaHoEJo5oE&list=PLUUjDC9sOrpktWjO7jNFwsisK0vi5d_Tx&index=11)      |
+| July 13, 2022 @ 17:00 CET      | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-12-13-July-2022-97096d02d1214d49896cb3fa88666901)      | no video available                                                                                         |
+| June 8, 2022 @ 17:00 CET       | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-11-8-June-2022-7497b347d88a466d8ee52f050c3e6f54)       | [video](https://youtu.be/j-zlRjEYtNA)                                                                      |
+| May 11, 2022 @ 17:00 CET       | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-10-11-May-2022-5d0f955f2c4e49c2bb42af014f230675)       | [video](https://www.youtube.com/watch?v=I0Tz73irWig&list=PLUUjDC9sOrpktWjO7jNFwsisK0vi5d_Tx&index=8)       |
+| April 13, 2022 @ 17:00 CET     | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-9-13-Apr-2022-6649a917e596418588a392a2a2b5f298)        | [video](https://youtu.be/XnWqP2XbW_8)                                                                      |
+| March 9, 2022 @ 17:00 CET      | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-8-9-Mar-2022-2952cf0a0e0c435cb6cd0b5bf0a07e51)         | [video](https://www.youtube.com/watch?v=GdXJk5SEVjA)                                                       |
+| February 9, 2022 @ 17:00 CET   | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-7-9-Feb-2022-4c57a576dbc146ee97c068fdae92910a)         | [video](https://www.youtube.com/watch?v=pgficI5YzSc&list=PLUUjDC9sOrpktWjO7jNFwsisK0vi5d_Tx&index=5)       |
+| January 12, 2022 @ 17:00 CET   | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-6-12-Jan-2022-16297fa7f64c4dc199b6bdc604a11b79)        | no video available                                                                                         |
+| December 8, 2021 @ 17:00 CET   | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-5-8-Dec-2021-9654bab20d124e66890298b8af569515)         | [video](https://www.youtube.com/watch?v=GMu0GIqcyLg)                                                       |
+| November 10, 2021 @ 17:00 CET  | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-4-10-Nov-2021-bc49bd96432e49e0be49cdb396bacbc0)        | no video available                                                                                         |
+| October 10, 2021 @ 17:00 CET   | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-3-13-Oct-2021-a7ca062d46b648f5b4ea5d0b172d396e)        | [video](https://www.youtube.com/watch?v=gDrSHmqNpwE)                                                       |
+| August 11, 2021 @ 17:00 CET    | [link](https://forest-text-046.notion.site/Monthly-Governance-Call-1-11-Aug-2021-ab9681da882a49ce9ea760b456ce2bc4)        | [video](https://www.youtube.com/watch?v=etPEDEUm5Ak&t=543s)                                                |

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Radicle Docs',
   tagline: 'A peer-to-peer stack for building software together.',
-  url: 'https://docs.radicle.xyz',
+  url: 'https://docs.radicle.community',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.radicle.xyz
+docs.radicle.community

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -4,7 +4,7 @@
 const siteConfig = {
   title: "Radicle docs",
   tagline: "A peer-to-peer stack for building software together.",
-  url: "https://docs.radicle.xyz",
+  url: "https://docs.radicle.community",
   baseUrl: "/",
   projectName: "radicle-docs",
   organizationName: "radicle-dev",

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,1 +1,1 @@
-docs.radicle.xyz
+docs.radicle.community


### PR DESCRIPTION
This documentation site is now deployed to `docs.radicle.community`. This PR updates a few URLs throughout the main README and a few other places to reflect that.

In addition, I made some changes to other URLs, like Beehiiv instead of Revue for the Digest, and incorporating the table of governance calls from #208.