### PR TITLE
Add external link icon to grid boxes

### DIFF
--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import ExternalLink from '@theme/Icon/ExternalLink';
 import styles from './Grid.module.css';
 
 export default function Grid ({ children }) {
@@ -12,10 +14,17 @@ export default function Grid ({ children }) {
 
 export function Button ({ children, style = {}, href, title, cta }) {
   return (
+    <>
     <Link to={href} className={styles.button} style={style}>
+      {!isInternalUrl(href) && (
+        <div className={styles.ext}>
+          <ExternalLink />
+        </div>
+      )}
       {title && <h3>{title}</h3>}
       {children && <p>{children}</p>}
       {cta && <p className={styles.cta}>{cta} &rarr;</p>}
     </Link>
+    </>
   );
 }

--- a/src/components/Grid.module.css
+++ b/src/components/Grid.module.css
@@ -32,10 +32,11 @@
 }
 
 .button {
+  position: relative;
   grid-column: span 6;
   border: 1px solid hsla(240, 100%, 66.7%, 0.7) !important;
   border-radius: 0.5rem;
-  padding: 1rem;
+  padding: 2rem;
 }
 
 .button:hover {
@@ -55,6 +56,18 @@
 
 .button p:last-of-type {
   margin-bottom: 0;
+}
+
+.ext {
+  position: absolute;
+  top: 2rem;
+  right: 2rem;
+  color: hsl(240, 100%, 66.7%);
+}
+
+.ext svg {
+  width: 20px;
+  height: 20px;
 }
 
 .cta {


### PR DESCRIPTION
Based on a comment I left on #243, I changed the `<Grid>` component to automatically add an icon if the URL points to an external site. Here's an example of what that looks like:

![image](https://user-images.githubusercontent.com/1153921/233458184-419e1006-1dd2-4019-b633-508b1cf13df6.png)